### PR TITLE
feat(create_doc): Introduce monday create_doc tool

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -1,0 +1,173 @@
+import { z } from 'zod';
+// GraphQL operations are defined centrally in queries.graphql.ts
+
+import {
+  createDoc as createDocMutation,
+  addContentToDocFromMarkdown,
+  getItemBoard,
+  createColumn as createColumnMutation,
+} from '../../../monday-graphql/queries.graphql';
+import { BoardKind, ColumnType } from '../../../monday-graphql/generated/graphql';
+import { ToolInputType, ToolOutputType, ToolType } from '../../tool';
+import { BaseMondayApiTool, createMondayApiAnnotations } from './base-monday-api-tool';
+// TODO - to create a doc title i should use the update title mutation
+export const createDocToolSchema = {
+  workspace_id: z
+    .number()
+    .optional()
+    .describe(
+      'Workspace ID under which to create the new document. Provide either workspace_id (for workspace docs) or item_id (for item-attached docs).',
+    ),
+  item_id: z
+    .number()
+    .optional()
+    .describe('Item ID to attach the new document to. If provided, a doc will be created on the item.'),
+  column_id: z
+    .string()
+    .optional()
+    .describe(
+      "ID of an existing 'doc' column on the board which contains the item. If not provided, the tool will create a new doc column automatically when creating a doc on an item.",
+    ),
+  doc_name: z
+    .string()
+    .optional()
+    .describe('Name for the new document (relevant for workspace docs). Defaults to "New Document" if not provided.'),
+  doc_kind: z
+    .nativeEnum(BoardKind)
+    .optional()
+    .describe('Document kind for workspace docs (public / private / share). Defaults to private.'),
+  markdown: z.string().describe('Markdown content that will be imported into the newly created document as blocks.'),
+};
+
+export class CreateDocTool extends BaseMondayApiTool<typeof createDocToolSchema> {
+  name = 'create_doc';
+  type = ToolType.WRITE;
+  annotations = createMondayApiAnnotations({
+    title: 'Create Document',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  });
+
+  getDescription(): string {
+    return `Create a new monday.com doc either inside a workspace or attached to an item (via a doc column). After creation, the provided markdown will be appended to the document.`;
+  }
+
+  getInputSchema(): typeof createDocToolSchema {
+    return createDocToolSchema;
+  }
+
+  protected async executeInternal(input: ToolInputType<typeof createDocToolSchema>): Promise<ToolOutputType<never>> {
+    // Validate mutually exclusive parameters
+    if (!input.workspace_id && !input.item_id) {
+      return {
+        content: 'Error: You must provide either workspace_id for a workspace doc or item_id for an item doc.',
+      };
+    }
+
+    if (input.workspace_id && input.item_id) {
+      return {
+        content: 'Error: Provide only one of workspace_id or item_id, not both.',
+      };
+    }
+
+    try {
+      let docId: string | undefined;
+      let docUrl: string | undefined;
+
+      if (input.workspace_id) {
+        // Workspace document creation
+        const locationInput = {
+          workspace: {
+            workspace_id: input.workspace_id.toString(),
+            name: input.doc_name || 'New Document',
+            kind: input.doc_kind || BoardKind.Private,
+          },
+        };
+
+        const res: any = await this.mondayApi.request(createDocMutation, { location: locationInput });
+        docId = res?.create_doc?.id;
+        docUrl = res?.create_doc?.url;
+      } else if (input.item_id) {
+        // Item-attached document creation
+        // Step 1: Resolve the board id and existing doc columns
+        const itemRes: any = await this.mondayApi.request(getItemBoard, {
+          itemId: input.item_id.toString(),
+        });
+
+        const item = itemRes?.items?.[0];
+        if (!item) {
+          return { content: `Error: Item with id ${input.item_id} not found.` };
+        }
+
+        const boardId = item.board.id;
+        const existingDocColumn = item.board.columns.find((c: any) => ['doc'].includes(c.type));
+
+        let columnId = input.column_id;
+
+        if (!columnId) {
+          if (existingDocColumn) {
+            columnId = existingDocColumn.id;
+          } else {
+            // Create new doc column on the board
+            const columnRes: any = await this.mondayApi.request(createColumnMutation, {
+              boardId: boardId.toString(),
+              columnType: ColumnType.Doc,
+              columnTitle: 'Doc',
+              columnDescription: undefined,
+              columnSettings: undefined,
+            });
+
+            columnId = columnRes?.create_column?.id;
+            if (!columnId) {
+              return { content: 'Error: Failed to create doc column.' };
+            }
+          }
+        }
+
+        // Step 2: Create the doc attached to the item and column
+        const locationInput = {
+          board: {
+            item_id: input.item_id.toString(),
+            column_id: columnId,
+          },
+        };
+
+        const res: any = await this.mondayApi.request(createDocMutation, { location: locationInput });
+        docId = res?.create_doc?.id;
+        docUrl = res?.create_doc?.url;
+      }
+
+      if (!docId) {
+        return { content: 'Error: Failed to create document.' };
+      }
+
+      // Step 3: Add markdown content to the doc
+      const contentRes: any = await this.mondayApi.request(addContentToDocFromMarkdown, {
+        docId,
+        markdown: input.markdown,
+      });
+
+      const success = contentRes?.add_content_to_doc_from_markdown?.success;
+      const errorMsg = contentRes?.add_content_to_doc_from_markdown?.error;
+
+      if (!success) {
+        return {
+          content: `Document ${docId} created, but failed to add markdown content: ${errorMsg || 'Unknown error'}`,
+        };
+      }
+
+      const blockIds = contentRes?.add_content_to_doc_from_markdown?.block_ids || [];
+
+      return {
+        content: `✅ Document successfully created (id: ${docId}). Markdown imported (${blockIds.length} blocks).${
+          docUrl ? `\n\nURL: ${docUrl}` : ''
+        }`,
+      };
+    } catch (error) {
+      return {
+        content: `Error creating document: ${error instanceof Error ? error.message : 'Unknown error'}`,
+      };
+    }
+  }
+}

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -49,7 +49,7 @@ export const createDocToolSchema = {
   location: CreateDocLocationSchema.describe(
     'Location where the document should be created - either in a workspace or attached to an item',
   ),
-  doc_name: z.string().optional().describe('Name for the new document. Defaults to "New Document" if not provided.'),
+  doc_name: z.string().describe('Name for the new document.'),
   markdown: z.string().describe('Markdown content that will be imported into the newly created document as blocks.'),
 };
 
@@ -187,8 +187,6 @@ USAGE EXAMPLES:
           content: `Document ${docId} created, but failed to add markdown content: ${errorMsg || 'Unknown error'}`,
         };
       }
-
-      const blockIds = contentRes?.add_content_to_doc_from_markdown?.block_ids || [];
 
       return {
         content: `✅ Document successfully created (id: ${docId}). ${docUrl ? `\n\nURL: ${docUrl}` : ''}`,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-// GraphQL operations are defined centrally in queries.graphql.ts
 
 import {
   createDoc as createDocMutation,
@@ -66,7 +65,6 @@ USAGE EXAMPLES:
   }
 
   protected async executeInternal(input: ToolInputType<typeof createDocToolSchema>): Promise<ToolOutputType<never>> {
-    // No need for validation - schema enforces exactly one location type
     try {
       let docId: string | undefined;
       let docUrl: string | undefined;
@@ -133,7 +131,7 @@ USAGE EXAMPLES:
         docId = res?.create_doc?.id;
         docUrl = res?.create_doc?.url;
 
-        // Step 2.5: Update doc name if provided (item-attached docs don't support name in creation)
+        // Step 3: Update doc name if provided (item-attached docs don't support name in creation)
         if (input.doc_name && docId) {
           try {
             await this.mondayApi.request(updateDocName, {
@@ -151,7 +149,7 @@ USAGE EXAMPLES:
         return { content: 'Error: Failed to create document.' };
       }
 
-      // Step 3: Add markdown content to the doc
+      // Add markdown content to the doc
       const contentRes: any = await this.mondayApi.request(addContentToDocFromMarkdown, {
         docId,
         markdown: input.markdown,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -32,6 +32,7 @@ const CreateDocLocationSchema = z.discriminatedUnion('type', [
     type: z.literal(DocType.enum.workspace).describe('Create document in workspace'),
     workspace_id: z.number().describe('Workspace ID under which to create the new document'),
     doc_kind: z.nativeEnum(BoardKind).optional().describe('Document kind (public/private/share). Defaults to public.'),
+    folder_id: z.number().optional().describe('Optional folder ID to place the document inside a specific folder'),
   }),
   z.object({
     type: z.literal(DocType.enum.item).describe('Create document attached to item'),
@@ -67,11 +68,12 @@ export class CreateDocTool extends BaseMondayApiTool<typeof createDocToolSchema>
     return `Create a new monday.com doc either inside a workspace or attached to an item (via a doc column). After creation, the provided markdown will be appended to the document.
 
 LOCATION TYPES:
-- workspace: Creates a document in a workspace (requires workspace_id, optional doc_kind)
+- workspace: Creates a document in a workspace (requires workspace_id, optional doc_kind, optional folder_id)
 - item: Creates a document attached to an item (requires item_id, optional column_id)
 
 USAGE EXAMPLES:
 - Workspace doc: { location: { type: "workspace", workspace_id: 123, doc_kind: "private" }, markdown: "..." }
+- Workspace doc in folder: { location: { type: "workspace", workspace_id: 123, folder_id: 17264196 }, markdown: "..." }
 - Item doc: { location: { type: "item", item_id: 456, column_id: "doc_col_1" }, markdown: "..." }`;
   }
 
@@ -92,6 +94,7 @@ USAGE EXAMPLES:
               workspace_id: input.location.workspace_id.toString(),
               name: input.doc_name,
               kind: input.location.doc_kind || BoardKind.Public,
+              folder_id: input.location.folder_id?.toString(),
             },
           },
         };

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -24,15 +24,17 @@ import {
 import { ToolInputType, ToolOutputType, ToolType } from '../../tool';
 import { BaseMondayApiTool, createMondayApiAnnotations } from './base-monday-api-tool';
 
+const DocType = z.enum(['workspace', 'item']);
+
 // Create discriminated union for document location
 const CreateDocLocationSchema = z.discriminatedUnion('type', [
   z.object({
-    type: z.literal('workspace').describe('Create document in workspace'),
+    type: z.literal(DocType.enum.workspace).describe('Create document in workspace'),
     workspace_id: z.number().describe('Workspace ID under which to create the new document'),
     doc_kind: z.nativeEnum(BoardKind).optional().describe('Document kind (public/private/share). Defaults to private.'),
   }),
   z.object({
-    type: z.literal('item').describe('Create document attached to item'),
+    type: z.literal(DocType.enum.item).describe('Create document attached to item'),
     item_id: z.number().describe('Item ID to attach the new document to'),
     column_id: z
       .string()

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -84,13 +84,13 @@ USAGE EXAMPLES:
       let docId: string | undefined;
       let docUrl: string | undefined;
 
-      if (input.location.type === 'workspace') {
+      if (input.location.type === DocType.enum.workspace) {
         // Workspace document creation
         const variables: CreateDocMutationVariables = {
           location: {
             workspace: {
               workspace_id: input.location.workspace_id.toString(),
-              name: input.doc_name || 'New Document',
+              name: input.doc_name,
               kind: input.location.doc_kind || BoardKind.Public,
             },
           },
@@ -99,7 +99,7 @@ USAGE EXAMPLES:
         const res: CreateDocMutation = await this.mondayApi.request(createDocMutation, variables);
         docId = res?.create_doc?.id ?? undefined;
         docUrl = res?.create_doc?.url ?? undefined;
-      } else if (input.location.type === 'item') {
+      } else if (input.location.type === DocType.enum.item) {
         // Item-attached document creation
         // Step 1: Resolve the board id and existing doc columns
         const variables: GetItemBoardQueryVariables = {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -31,7 +31,7 @@ const CreateDocLocationSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal(DocType.enum.workspace).describe('Create document in workspace'),
     workspace_id: z.number().describe('Workspace ID under which to create the new document'),
-    doc_kind: z.nativeEnum(BoardKind).optional().describe('Document kind (public/private/share). Defaults to private.'),
+    doc_kind: z.nativeEnum(BoardKind).optional().describe('Document kind (public/private/share). Defaults to public.'),
   }),
   z.object({
     type: z.literal(DocType.enum.item).describe('Create document attached to item'),
@@ -91,7 +91,7 @@ USAGE EXAMPLES:
             workspace: {
               workspace_id: input.location.workspace_id.toString(),
               name: input.doc_name || 'New Document',
-              kind: input.location.doc_kind || BoardKind.Private,
+              kind: input.location.doc_kind || BoardKind.Public,
             },
           },
         };

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool.ts
@@ -11,7 +11,7 @@ import {
 import { BoardKind, ColumnType } from '../../../monday-graphql/generated/graphql';
 import { ToolInputType, ToolOutputType, ToolType } from '../../tool';
 import { BaseMondayApiTool, createMondayApiAnnotations } from './base-monday-api-tool';
-// TODO - to create a doc title i should use the update title mutation
+
 export const createDocToolSchema = {
   workspace_id: z
     .number()
@@ -27,7 +27,7 @@ export const createDocToolSchema = {
     .string()
     .optional()
     .describe(
-      "ID of an existing 'doc' column on the board which contains the item. If not provided, the tool will create a new doc column automatically when creating a doc on an item.",
+      'ID of a specific doc column to use. If not provided, the tool will automatically find the first existing doc column or create a new one. Useful when the board has multiple doc columns and you want to specify which one to use.',
     ),
   doc_name: z
     .string()

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -18,6 +18,7 @@ import { GetTypeDetailsTool } from './get-type-details-tool';
 import { GetUsersTool } from './get-users-tool';
 import { MoveItemToGroupTool } from './move-item-to-group-tool';
 import { ReadDocsTool } from './read-docs-tool';
+import { CreateDocTool } from './create-doc-tool';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   DeleteItemTool,
@@ -39,6 +40,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   FetchCustomActivityTool,
   CreateWorkflowInstructionsTool,
   ReadDocsTool,
+  CreateDocTool,
 ];
 
 export * from './all-monday-api-tool';
@@ -61,3 +63,4 @@ export * from './manage-tools-tool';
 export * from './move-item-to-group-tool';
 export * from './create-workflow-instructions-tool';
 export * from './read-docs-tool';
+export * from './create-doc-tool';

--- a/packages/agent-toolkit/src/monday-graphql/generated/graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/generated/graphql.ts
@@ -6381,6 +6381,37 @@ export type FetchCustomActivityQueryVariables = Exact<{ [key: string]: never; }>
 
 export type FetchCustomActivityQuery = { __typename?: 'Query', custom_activity?: Array<{ __typename?: 'CustomActivity', color?: CustomActivityColor | null, icon_id?: CustomActivityIcon | null, id?: string | null, name?: string | null, type?: string | null }> | null };
 
+export type GetItemBoardQueryVariables = Exact<{
+  itemId: Scalars['ID']['input'];
+}>;
+
+
+export type GetItemBoardQuery = { __typename?: 'Query', items?: Array<{ __typename?: 'Item', id: string, board?: { __typename?: 'Board', id: string, columns?: Array<{ __typename?: 'Column', id: string, type: ColumnType } | null> | null } | null } | null> | null };
+
+export type CreateDocMutationVariables = Exact<{
+  location: CreateDocInput;
+}>;
+
+
+export type CreateDocMutation = { __typename?: 'Mutation', create_doc?: { __typename?: 'Document', id: string, url?: string | null, name: string } | null };
+
+export type AddContentToDocFromMarkdownMutationVariables = Exact<{
+  docId: Scalars['ID']['input'];
+  markdown: Scalars['String']['input'];
+  afterBlockId?: InputMaybe<Scalars['String']['input']>;
+}>;
+
+
+export type AddContentToDocFromMarkdownMutation = { __typename?: 'Mutation', add_content_to_doc_from_markdown?: { __typename?: 'DocBlocksFromMarkdownResult', success: boolean, block_ids?: Array<string> | null, error?: string | null } | null };
+
+export type UpdateDocNameMutationVariables = Exact<{
+  docId: Scalars['ID']['input'];
+  name: Scalars['String']['input'];
+}>;
+
+
+export type UpdateDocNameMutation = { __typename?: 'Mutation', update_doc_name?: any | null };
+
 export type ReadDocsQueryVariables = Exact<{
   ids?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
   object_ids?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;

--- a/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
@@ -471,6 +471,13 @@ export const addContentToDocFromMarkdown = gql`
   }
 `;
 
+// Update the name/title of an existing monday doc (API version 2025-10)
+export const updateDocName = gql`
+  mutation updateDocName($docId: ID!, $name: String!) {
+    update_doc_name(docId: $docId, name: $name)
+  }
+`;
+
 export const readDocs = gql`
   query readDocs(
     $ids: [ID!]

--- a/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
@@ -429,6 +429,48 @@ export const fetchCustomActivity = gql`
   }
 `;
 
+// -----------------------------
+// Documents (Docs) Operations
+// -----------------------------
+
+// Get item board and its columns (used to discover or create a doc column for item-attached docs)
+export const getItemBoard = gql`
+  query getItemBoard($itemId: ID!) {
+    items(ids: [$itemId]) {
+      id
+      board {
+        id
+        columns {
+          id
+          type
+        }
+      }
+    }
+  }
+`;
+
+// Create a new monday doc (works for both workspace and board/item locations via CreateDocInput)
+export const createDoc = gql`
+  mutation createDoc($location: CreateDocInput!) {
+    create_doc(location: $location) {
+      id
+      url
+      name
+    }
+  }
+`;
+
+// Add markdown content to an existing monday doc (API version 2025-10)
+export const addContentToDocFromMarkdown = gql`
+  mutation addContentToDocFromMarkdown($docId: ID!, $markdown: String!, $afterBlockId: String) {
+    add_content_to_doc_from_markdown(docId: $docId, markdown: $markdown, afterBlockId: $afterBlockId) {
+      success
+      block_ids
+      error
+    }
+  }
+`;
+
 export const readDocs = gql`
   query readDocs(
     $ids: [ID!]


### PR DESCRIPTION
Create monday doc tool - Workspace doc (leftpane) or Doc on item (board)

* If provided workspace id - will create workspace doc, 
* If provided item id - will create doc on this item - if the board wont have a doc column on it, we will create new doc column.
* Adding content to the created doc as markdown.
