### PR TITLE
Add isError=true when there is an error

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.16.0",
+  "version": "2.16.1",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -105,7 +105,6 @@ export * from './get-users-tool';
 export * from './list-users-and-teams-tool/list-users-and-teams-tool';
 export * from './manage-tools-tool';
 export * from './move-item-to-group-tool';
-export * from './create-workflow-instructions-tool';
 export * from './read-docs-tool';
 export * from './workspace-info-tool/workspace-info-tool';
 export * from './list-workspace-tool/list-workspace-tool';

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -197,6 +197,7 @@ export class MondayAgentToolkit extends McpServer {
           text: `Failed to execute tool ${toolName}: ${errorMessage}`,
         },
       ],
+      isError: true
     };
   }
 }


### PR DESCRIPTION
Very small change to the `handleToolError` output to add `isError=true`

This aligns with the spec guidance (https://modelcontextprotocol.io/specification/2025-06-18/server/tools#error-handling) and makes it easier for tools like the MCP Inspector (https://github.com/modelcontextprotocol/inspector) to provide nice UX.
