### PR TITLE
SubItem creation via CreateItem Tool

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.17.0",
+  "version": "2.18.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-item-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-item-tool.ts
@@ -1,6 +1,8 @@
 import { z } from 'zod';
 import { CreateItemMutation, CreateItemMutationVariables, DuplicateItemMutation, CreateSubitemMutation } from '../../../../monday-graphql/generated/graphql';
-import { createItem, duplicateItem, createSubitem } from '../../../../monday-graphql/queries.graphql';
+import { createItem } from '../../../../monday-graphql/queries.graphql';
+import { duplicateItem } from './duplicate-item.graphql';
+import { createSubitem } from './create-subitem.graphql';
 import { ToolInputType, ToolOutputType, ToolType } from '../../../tool';
 import { BaseMondayApiTool, createMondayApiAnnotations } from '../base-monday-api-tool';
 import { ChangeItemColumnValuesTool } from '../change-item-column-values-tool';
@@ -42,7 +44,7 @@ export class CreateItemTool extends BaseMondayApiTool<CreateItemToolInput> {
   });
 
   getDescription(): string {
-    return 'Create a new item with provided values, create a subitem under a parent item, or duplicate an existing item and update it with new values';
+    return 'Create a new item with provided values, create a subitem under a parent item, or duplicate an existing item and update it with new values. Use parentItemId when creating a subitem under an existing item. Use duplicateFromItemId when copying an existing item with modifications.';
   }
 
   getInputSchema(): CreateItemToolInput {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-item-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-item-tool.ts
@@ -124,7 +124,7 @@ export class CreateItemTool extends BaseMondayApiTool<CreateItemToolInput> {
         const res = await this.mondayApi.request<CreateSubitemMutation>(createSubitem, variables);
 
       if (!res.create_subitem?.id) {
-        throw new Error(' No subitem created');
+        throw new Error('Failed to create subitem: no subitem created');
       }
 
       return {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-subitem.graphql.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-subitem.graphql.ts
@@ -1,0 +1,13 @@
+import { gql } from 'graphql-request';
+
+export const createSubitem = gql`
+  mutation createSubitem($parentItemId: ID!, $itemName: String!, $columnValues: JSON) {
+    create_subitem(parent_item_id: $parentItemId, item_name: $itemName, column_values: $columnValues) {
+      id
+      name
+      parent_item {
+        id
+      }
+    }
+  }
+`;

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/duplicate-item.graphql.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/duplicate-item.graphql.ts
@@ -1,0 +1,10 @@
+import { gql } from 'graphql-request';
+
+export const duplicateItem = gql`
+  mutation duplicateItem($boardId: ID!, $itemId: ID!, $withUpdates: Boolean) {
+    duplicate_item(board_id: $boardId, item_id: $itemId, with_updates: $withUpdates) {
+      id
+      name
+    }
+  }
+`;

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/test-utils/mock-api-client.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/test-utils/mock-api-client.ts
@@ -28,10 +28,14 @@ export function createMockApiClient() {
       mockRequest.mockResolvedValue(data);
     },
 
-    setError: (message: string, path: string[] = []) => {
-      const error = new Error(message);
-      (error as any).errors = [{ message, path }];
-      mockRequest.mockRejectedValue(error);
+    setError: (messageOrError: string | Error, path: string[] = []) => {
+      if (typeof messageOrError === 'string') {
+        const error = new Error(messageOrError);
+        (error as any).errors = [{ message: messageOrError, path }];
+        mockRequest.mockRejectedValue(error);
+      } else {
+        mockRequest.mockRejectedValue(messageOrError);
+      }
     },
  
 

--- a/packages/agent-toolkit/src/monday-graphql/generated/graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/generated/graphql.ts
@@ -9128,3 +9128,12 @@ export type DuplicateItemMutationVariables = Exact<{
 
 
 export type DuplicateItemMutation = { __typename?: 'Mutation', duplicate_item?: { __typename?: 'Item', id: string, name: string } | null };
+
+export type CreateSubitemMutationVariables = Exact<{
+  parentItemId: Scalars['ID']['input'];
+  itemName: Scalars['String']['input'];
+  columnValues?: InputMaybe<Scalars['JSON']['input']>;
+}>;
+
+
+export type CreateSubitemMutation = { __typename?: 'Mutation', create_subitem?: { __typename?: 'Item', id: string, name: string, parent_item?: { __typename?: 'Item', id: string } | null } | null };

--- a/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
@@ -569,3 +569,15 @@ export const duplicateItem = gql`
   }
 `;
 
+export const createSubitem = gql`
+  mutation createSubitem($parentItemId: ID!, $itemName: String!, $columnValues: JSON) {
+    create_subitem(parent_item_id: $parentItemId, item_name: $itemName, column_values: $columnValues) {
+      id
+      name
+      parent_item {
+        id
+      }
+    }
+  }
+`;
+

--- a/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
@@ -560,24 +560,4 @@ export const getWorkspaceInfo = gql`
   }
 `;
 
-export const duplicateItem = gql`
-  mutation duplicateItem($boardId: ID!, $itemId: ID!, $withUpdates: Boolean) {
-    duplicate_item(board_id: $boardId, item_id: $itemId, with_updates: $withUpdates) {
-      id
-      name
-    }
-  }
-`;
-
-export const createSubitem = gql`
-  mutation createSubitem($parentItemId: ID!, $itemName: String!, $columnValues: JSON) {
-    create_subitem(parent_item_id: $parentItemId, item_name: $itemName, column_values: $columnValues) {
-      id
-      name
-      parent_item {
-        id
-      }
-    }
-  }
-`;
 


### PR DESCRIPTION
This PR extends the `CreateItemTool` to support creating subitems under parent items, in addition to the existing functionality for creating regular items and duplicating items.

## Implementation Details

Extended the tool to handle three distinct paths:
  1. Duplicate existing item (when `duplicateFromItemId` is provided)
  2. Create subitem (when `parentItemId` is provided) 
  3. Create regular item (default behaviour)

This should be fully backwards compatible with existing tool calls.