### PR TITLE
Modify error handling for the search

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.20.0",
+  "version": "2.20.1",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
Adjusted logic for calling new search to fallback to "name contains <term>" filter when new search is not enabled for specific account (error code LIVE_INDEXING_NOT_ENABLED_FOR_ACCOUNT)