### PR TITLE
Fixed read-only mode not able to retrieve any board data. Added execution-level protection while in read-only mode.

### DIFF
--- a/packages/agent-toolkit/src/utils/tools/tools-filtering.utils.ts
+++ b/packages/agent-toolkit/src/utils/tools/tools-filtering.utils.ts
@@ -31,9 +31,6 @@ export const getFilteredToolInstances = (
     if (config.mode === ToolMode.API && config.enableDynamicApiTools === false) {
       shouldFilter = shouldFilter || toolInstance.type === ToolType.ALL_API;
     }
-    if (config.readOnlyMode) {
-      shouldFilter = shouldFilter || toolInstance.type !== ToolType.READ;
-    }
     if (config.include) {
       shouldFilter = shouldFilter || !config.include?.includes(toolInstance.name);
     } else if (config.exclude) {


### PR DESCRIPTION
This is to address the raised Issue # 111.

1. Fixed the issue that when read-only mode is enabled, MCP is not able to retrieve any actual data (i.e. values in the columns) from the board, so the read-only mode is not really usable.

2.Added execution-level protection while in read-only mode to prevent any 'write' or 'all_api' tool from executing.