### PR TITLE
bump agent toolkit version

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.34.0",
+  "version": "2.35.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
bump version to re-pubilsh , previous PR (https://github.com/mondaycom/mcp/pull/187) failed on version already existing