### PR TITLE
Rename event to monday_apps_mcp_tool_execution

### DIFF
--- a/packages/agent-toolkit/src/core/tools/monday-apps-tools/base-tool/base-monday-apps-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-apps-tools/base-tool/base-monday-apps-tool.ts
@@ -203,7 +203,7 @@ export abstract class BaseMondayAppsTool<
     const tokenInfo = this.mondayApiToken ? extractTokenInfo(this.mondayApiToken) : {};
 
     trackEvent({
-      name: 'monday_mcp_tool_execution',
+      name: 'monday_apps_mcp_tool_execution',
       data: {
         toolName,
         executionTimeMs,


### PR DESCRIPTION
## Summary
Renamed tracking event from `monday_mcp_tool_execution` to `monday_apps_mcp_tool_execution` to better reflect that this event is specifically for Monday apps MCP tools.

## Changes
- Updated event name in `BaseMondayAppsTool.trackToolExecution()` method

🤖 Generated with [Claude Code](https://claude.com/claude-code)