### PR TITLE
Bump agent-toolkit version to 2.36.3

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.36.2",
+  "version": "2.36.3",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
## Summary
Version bump to 2.36.3 for the event name change released in #194.

## Changes
- Bumped version from 2.36.2 to 2.36.3 in agent-toolkit package.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)