### PR TITLE
Bump agent-toolkit version to 2.37.0

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.36.3",
+  "version": "2.37.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
## Summary
- Bumps `@mondaydotcomorg/agent-toolkit` from `2.36.3` → `2.37.0` (minor bump for new feature).
- Required for the new `add_content_to_doc` tool added in #205.

## Monday Item
https://monday.monday.com/boards/3713040192/pulses/11335259558

## Test plan
- [ ] Verify package publishes correctly with the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)