### PR TITLE
chore: bump agent-toolkit version to 2.39.0

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "2.38.0",
+  "version": "2.39.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
## Summary
- Bumped agent-toolkit package version from 2.38.0 to 2.39.0

## Test plan
- [ ] Version number updated correctly in package.json
- [ ] Package builds successfully
- [ ] No breaking changes introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)