### PR TITLE
[POC] Add MCP tool schema regression testing with mcp-recorder

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -23,3 +23,18 @@ jobs:
 
       - name: Test packages
         run: yarn test
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install snapshot testing dependencies
+        run: pip install -r integration/requirements.txt
+
+      - name: Verify snapshot tests
+        run: |
+          mcp-recorder verify \
+            --cassette integration/cassettes/list_tools.json \
+            --target-stdio "node packages/monday-api-mcp/dist/index.js" \
+            --target-env MONDAY_TOKEN=test-token

--- a/integration/cassettes/list_tools.json
+++ b/integration/cassettes/list_tools.json
@@ -1,0 +1,3196 @@
+{
+  "version": "1.0",
+  "metadata": {
+    "recorded_at": "2026-03-04T08:57:44.784239+00:00",
+    "server_url": "stdio://node packages/[REDACTED]",
+    "transport_type": "stdio",
+    "protocol_version": "2025-06-18",
+    "server_info": {
+      "name": "monday.com",
+      "version": "1.0.0"
+    }
+  },
+  "interactions": [
+    {
+      "type": "jsonrpc_request",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 0,
+        "method": "initialize",
+        "params": {
+          "protocolVersion": "2025-11-25",
+          "capabilities": {},
+          "clientInfo": {
+            "name": "mcp-recorder",
+            "version": "0.1.0"
+          }
+        }
+      },
+      "response": {
+        "result": {
+          "protocolVersion": "2025-06-18",
+          "capabilities": {
+            "tools": {
+              "listChanged": true
+            }
+          },
+          "serverInfo": {
+            "name": "monday.com",
+            "version": "1.0.0"
+          }
+        },
+        "jsonrpc": "2.0",
+        "id": 0
+      },
+      "response_is_sse": false,
+      "response_status": 200,
+      "latency_ms": 161,
+      "http_method": null,
+      "http_path": null
+    },
+    {
+      "type": "notification",
+      "request": {
+        "jsonrpc": "2.0",
+        "method": "notifications/initialized"
+      },
+      "response": null,
+      "response_is_sse": false,
+      "response_status": 202,
+      "latency_ms": 0,
+      "http_method": null,
+      "http_path": null
+    },
+    {
+      "type": "jsonrpc_request",
+      "request": {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "tools/list",
+        "params": {}
+      },
+      "response": {
+        "result": {
+          "tools": [
+            {
+              "name": "delete_item",
+              "title": "Delete Item",
+              "description": "Delete an item",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "itemId": {
+                    "type": "number"
+                  }
+                },
+                "required": [
+                  "itemId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Delete Item",
+                "readOnlyHint": false,
+                "destructiveHint": true,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "get_board_items_page",
+              "title": "Get Board Items Page",
+              "description": "Get all items from a monday.com board with pagination support and optional column values. Returns structured JSON with item details, creation/update timestamps, and pagination info. Use the 'nextCursor' parameter from the response to get the next page of results when 'has_more' is true.[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board's structure (column IDs, column types, status labels, etc.), first use get_board_info to understand the board metadata. This is essential for constructing proper filters and knowing which columns are available.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to get items from"
+                  },
+                  "itemIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "description": "The ids of the items to get. The count of items should be less than 100."
+                  },
+                  "searchTerm": {
+                    "type": "string",
+                    "description": "\n    The search term to use for the search.\n    - Use this when: the user provides a vague, incomplete, or approximate search term (e.g., “marketing campaign”, “John’s task”, “budget-related”), and there isn’t a clear exact compare value for a specific field.\n    - Do not use this when: the user specifies an exact value that maps directly to a column comparison (e.g., name contains \"marketing campaign\", status = \"Done\", priority = \"High\", owner = \"Daniel\"). In these cases, prefer structured compare filters.\n  "
+                  },
+                  "limit": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 500,
+                    "default": 25,
+                    "description": "The number of items to get"
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "The cursor to get the next page of items, use the nextCursor from the previous response. If the nextCursor was null, it means there are no more items to get"
+                  },
+                  "includeColumns": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to include column values in the response.\nPERFORMANCE OPTIMIZATION: Only set this to true when you actually need the column data. Excluding columns significantly reduces token usage and improves response latency. If you only need to count items, get item IDs/names, or check if items exist, keep this false."
+                  },
+                  "includeSubItems": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to include sub items in the response. PERFORMANCE OPTIMIZATION: Only set this to true when you actually need the sub items data."
+                  },
+                  "subItemLimit": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "The number of sub items to get per item. This is only used when includeSubItems is true."
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "columnId": {
+                          "type": "string",
+                          "description": "The id of the column to filter by"
+                        },
+                        "compareAttribute": {
+                          "type": "string",
+                          "description": "The attribute to compare the value to. This is OPTIONAL property."
+                        },
+                        "compareValue": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "number"
+                                ]
+                              }
+                            }
+                          ],
+                          "description": "The value to compare the attribute to. This can be a string or index value depending on the column type."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "any_of",
+                            "between",
+                            "contains_terms",
+                            "contains_text",
+                            "ends_with",
+                            "greater_than",
+                            "greater_than_or_equals",
+                            "is_empty",
+                            "is_not_empty",
+                            "lower_than",
+                            "lower_than_or_equal",
+                            "not_any_of",
+                            "not_contains_text",
+                            "starts_with",
+                            "within_the_last",
+                            "within_the_next"
+                          ],
+                          "default": "any_of",
+                          "description": "The operator to use for the filter"
+                        }
+                      },
+                      "required": [
+                        "columnId",
+                        "compareValue"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "The configuration of filters to apply on the items. Before sending the filters, use get_board_info tool to check \"filteringGuidelines\" key for filtering by the column."
+                  },
+                  "filtersOperator": {
+                    "type": "string",
+                    "enum": [
+                      "and",
+                      "or"
+                    ],
+                    "default": "and",
+                    "description": "The operator to use for the filters"
+                  },
+                  "columnIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "The ids of the item columns and subitem columns to get, can be used to reduce the response size when user asks for specific columns. Works only when includeColumns is true. If not provided, all columns will be returned"
+                  },
+                  "orderBy": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "columnId": {
+                          "type": "string",
+                          "description": "The id of the column to order by"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "asc",
+                            "desc"
+                          ],
+                          "default": "asc",
+                          "description": "The direction to order by"
+                        }
+                      },
+                      "required": [
+                        "columnId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "The columns to order by, will control the order of the items in the response"
+                  }
+                },
+                "required": [
+                  "boardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Board Items Page",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_item",
+              "title": "Create Item",
+              "description": "Create a new item with provided values, create a subitem under a parent item, or duplicate an existing item and update it with new values. Use parentItemId when creating a subitem under an existing item. Use duplicateFromItemId when copying an existing item with modifications.[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board's structure (column IDs, column types, status labels, etc.), first use get_board_info to understand the board metadata. This is essential for constructing proper column values and knowing which columns are available.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to which the new item will be added"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the new item to be created, must be relevant to the user's request"
+                  },
+                  "groupId": {
+                    "type": "string",
+                    "description": "The id of the group id to which the new item will be added, if its not clearly specified, leave empty"
+                  },
+                  "columnValues": {
+                    "type": "string",
+                    "description": "A string containing the new column values for the item following this structure: {\\\"column_id\\\": \\\"value\\\",... you can change multiple columns at once, note that for status column you must use nested value with 'label' as a key and for date column use 'date' as key} - example: \"{\\\"text_column_id\\\":\\\"New text\\\", \\\"status_column_id\\\":{\\\"label\\\":\\\"Done\\\"}, \\\"date_column_id\\\":{\\\"date\\\":\\\"2023-05-25\\\"},\\\"dropdown_id\\\":\\\"value\\\", \\\"phone_id\\\":\\\"123-456-7890\\\", \\\"email_id\\\":\\\"test@example.com\\\"}\""
+                  },
+                  "parentItemId": {
+                    "type": "number",
+                    "description": "The id of the parent item under which the new subitem will be created"
+                  },
+                  "duplicateFromItemId": {
+                    "type": "number",
+                    "description": "The id of existing item to duplicate and update with new values (only provide when duplicating)"
+                  }
+                },
+                "required": [
+                  "boardId",
+                  "name",
+                  "columnValues"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Item",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_update",
+              "title": "Create Update",
+              "description": "Create a new update (comment/post) on a monday.com item. Updates can be used to add comments, notes, or discussions to items. You can optionally mention users, teams, or boards in the update. You can also reply to an existing update by using the parentId parameter.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "itemId": {
+                    "type": "number",
+                    "description": "The id of the item to which the update will be added"
+                  },
+                  "body": {
+                    "type": "string",
+                    "description": "The update text to be created. Do not use @ to mention users, use the mentionsList field instead. use html tags to format the text, dont use markdown."
+                  },
+                  "mentionsList": {
+                    "type": "string",
+                    "description": "Optional JSON array of mentions in the format: [{\"id\": \"123\", \"type\": \"User\"}, {\"id\": \"456\", \"type\": \"Team\"}]. Valid types are: User, Team, Board, Project"
+                  },
+                  "parentId": {
+                    "type": "number",
+                    "description": "The ID of the update to reply to. Use this parameter when you want to reply on an existing update leave it empty if you want to create a new update"
+                  }
+                },
+                "required": [
+                  "itemId",
+                  "body"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Update",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "get_updates",
+              "title": "Get Updates",
+              "description": "Get updates (comments/posts) from a monday.com item or board. Specify objectId and objectType (Item or Board) to retrieve updates. Returns update text, creator info, timestamps, and optionally replies and assets.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "objectId": {
+                    "type": "string",
+                    "description": "The ID of the item or board to get updates from"
+                  },
+                  "objectType": {
+                    "type": "string",
+                    "enum": [
+                      "Item",
+                      "Board"
+                    ],
+                    "description": "Type of object for which objectId was provided"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Number of updates per page (default: 25, max: 100)"
+                  },
+                  "page": {
+                    "type": "number",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "Page number for pagination (default: 1)"
+                  },
+                  "includeReplies": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include update replies in the response"
+                  },
+                  "includeAssets": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Include file attachments in the response"
+                  }
+                },
+                "required": [
+                  "objectId",
+                  "objectType"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Updates",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_update_in_monday",
+              "title": "Create Update in Monday, after calling this tool you should",
+              "description": "Create a new update (comment/post) on a monday.com item. Updates can be used to add comments, notes, or discussions to items. You can optionally mention users, teams, or boards in the update. After calling this tool you should call the full board data tool to get data, and immediately after that call the show table tool to show the data from that tool. IMPORTANT: You MUST use the COMPLETE data from the full board data tool - do NOT cut, truncate, or omit any data. Pass the entire dataset to the show table tool.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "itemId": {
+                    "type": "number",
+                    "description": "The id of the item to which the update will be added"
+                  },
+                  "body": {
+                    "type": "string",
+                    "description": "The update text to be created. Do not use @ to mention users, use the mentionsList field instead."
+                  },
+                  "mentionsList": {
+                    "type": "string",
+                    "description": "Optional JSON array of mentions in the format: [{\"id\": \"123\", \"type\": \"User\"}, {\"id\": \"456\", \"type\": \"Team\"}]. Valid types are: User, Team, Board, Project"
+                  }
+                },
+                "required": [
+                  "itemId",
+                  "body"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Update in Monday, after calling this tool you should",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "get_board_schema",
+              "title": "Get Board Schema",
+              "description": "Get board schema (columns and groups) by board id",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to get the schema of"
+                  }
+                },
+                "required": [
+                  "boardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Board Schema",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_board_activity",
+              "title": "Get Board Activity",
+              "description": "Get board activity logs for a specified time range (defaults to last 30 days)",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to get activity for"
+                  },
+                  "fromDate": {
+                    "type": "string",
+                    "description": "Start date for activity range (ISO8601DateTime format). Defaults to 30 days ago"
+                  },
+                  "toDate": {
+                    "type": "string",
+                    "description": "End date for activity range (ISO8601DateTime format). Defaults to now"
+                  }
+                },
+                "required": [
+                  "boardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Board Activity",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_board_info",
+              "title": "Get Board Info",
+              "description": "Get comprehensive board information including metadata, structure, owners, and configuration",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to get information for"
+                  }
+                },
+                "required": [
+                  "boardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Board Info",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_full_board_data",
+              "title": "Get Full Board Data",
+              "description": "INTERNAL USE ONLY - DO NOT CALL THIS TOOL DIRECTLY. This tool is exclusively triggered by UI components and should never be invoked directly by the agent.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "string",
+                    "description": "The ID of the board to fetch complete data for"
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "columnId": {
+                          "type": "string",
+                          "description": "The id of the column to filter by"
+                        },
+                        "compareAttribute": {
+                          "type": "string",
+                          "description": "The attribute to compare the value to. This is OPTIONAL property."
+                        },
+                        "compareValue": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "number"
+                                ]
+                              }
+                            }
+                          ],
+                          "description": "The value to compare the attribute to. This can be a string or index value depending on the column type."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "any_of",
+                            "between",
+                            "contains_terms",
+                            "contains_text",
+                            "ends_with",
+                            "greater_than",
+                            "greater_than_or_equals",
+                            "is_empty",
+                            "is_not_empty",
+                            "lower_than",
+                            "lower_than_or_equal",
+                            "not_any_of",
+                            "not_contains_text",
+                            "starts_with",
+                            "within_the_last",
+                            "within_the_next"
+                          ],
+                          "default": "any_of",
+                          "description": "The operator to use for the filter"
+                        }
+                      },
+                      "required": [
+                        "columnId",
+                        "compareValue"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "The configuration of filters to apply on the items. Before sending the filters, use get_board_info tool to check \"filteringGuidelines\" key for filtering by the column."
+                  },
+                  "filtersOperator": {
+                    "type": "string",
+                    "enum": [
+                      "and",
+                      "or"
+                    ],
+                    "default": "and",
+                    "description": "The operator to use for the filters"
+                  }
+                },
+                "required": [
+                  "boardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Full Board Data",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "list_users_and_teams",
+              "title": "List Users and Teams",
+              "description": "Tool to fetch users and/or teams data. \n\n      MANDATORY BEST PRACTICES:\n      1. ALWAYS use specific IDs or names when available\n      2. If no ids available, use name search if possible (USERS ONLY)\n      3. Use 'getMe: true' to get current user information\n      4. AVOID broad queries (no parameters) - use only as last resort\n\n      REQUIRED PARAMETER PRIORITY (use in this order):\n      1. getMe - STANDALONE\n      2. userIds\n      3. name - STANDALONE (USERS ONLY, NOT for teams)\n      4. teamIds + teamsOnly\n      5. No parameters - LAST RESORT\n\n      CRITICAL USAGE RULES:\n      • userIds + teamIds requires explicit includeTeams: true flag\n      • includeTeams: true fetches both users and teams, do not use this to fetch a specific user's teams rather fetch that user by id and you will get their team memberships.\n      • name parameter is for USER search ONLY - it cannot be used to search for teams. Use teamIds to fetch specific teams.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "userIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 500,
+                    "description": "Specific user IDs to fetch.[IMPORTANT] ALWAYS use when you have user IDs in context. PREFER over general search. RETURNS: user profiles including team memberships"
+                  },
+                  "teamIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "maxItems": 500,
+                    "description": "Specific team IDs to fetch.[IMPORTANT] ALWAYS use when you have team IDs in context, NEVER fetch all teams if specific IDs are available.\n      RETURNS: Team details with owners and optional member data."
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "Name-based USER search ONLY. STANDALONE parameter - cannot be combined with others. PREFERRED method for finding users when you know names. Performs fuzzy matching.\n      CRITICAL: This parameter searches for USERS ONLY, NOT teams. To search for teams, use teamIds parameter instead."
+                  },
+                  "getMe": {
+                    "type": "boolean",
+                    "description": "[TOP PRIORITY] Use ALWAYS when requesting current user information. Examples of when it should be used: [\"get my user\" or \"get my teams\"].\n      This parameter CONFLICTS with all others. "
+                  },
+                  "includeTeams": {
+                    "type": "boolean",
+                    "description": "[AVOID] This fetches all teams in the account. To fetch a specific user's teams just fetch that user by id and you will get their team memberships."
+                  },
+                  "teamsOnly": {
+                    "type": "boolean",
+                    "description": "Fetch only teams, no users returned. Combine with includeTeamMembers for member details."
+                  },
+                  "includeTeamMembers": {
+                    "type": "boolean",
+                    "description": "Set to true only when you need additional member details for teams other than names and ids."
+                  }
+                },
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "List Users and Teams",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "change_item_column_values",
+              "title": "Change Item Column Values",
+              "description": "Change the column values of an item in a monday.com board",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The ID of the board that contains the item to be updated"
+                  },
+                  "itemId": {
+                    "type": "number",
+                    "description": "The ID of the item to be updated"
+                  },
+                  "columnValues": {
+                    "type": "string",
+                    "description": "A string containing the new column values for the item following this structure: {\\\"column_id\\\": \\\"value\\\",... you can change multiple columns at once, note that for status column you must use nested value with 'label' as a key and for date column use 'date' as key} - example: \"{\\\"text_column_id\\\":\\\"New text\\\", \\\"status_column_id\\\":{\\\"label\\\":\\\"Done\\\"}, \\\"date_column_id\\\":{\\\"date\\\":\\\"2023-05-25\\\"}, \\\"phone_id\\\":\\\"123-456-7890\\\", \\\"email_id\\\":\\\"test@example.com\\\"}\""
+                  }
+                },
+                "required": [
+                  "boardId",
+                  "itemId",
+                  "columnValues"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Change Item Column Values",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "move_item_to_group",
+              "title": "Move Item to Group",
+              "description": "Move an item to a group in a monday.com board",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "itemId": {
+                    "type": "number",
+                    "description": "The id of the item to which the update will be added"
+                  },
+                  "groupId": {
+                    "type": "string",
+                    "description": "The id of the group to which the item will be moved"
+                  }
+                },
+                "required": [
+                  "itemId",
+                  "groupId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Move Item to Group",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_board",
+              "title": "Create Board",
+              "description": "Create a monday.com board",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardName": {
+                    "type": "string",
+                    "description": "The name of the board to create"
+                  },
+                  "boardKind": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "public",
+                      "share"
+                    ],
+                    "default": "public",
+                    "description": "The kind of board to create"
+                  },
+                  "boardDescription": {
+                    "type": "string",
+                    "description": "The description of the board to create"
+                  },
+                  "workspaceId": {
+                    "type": "string",
+                    "description": "The ID of the workspace to create the board in"
+                  }
+                },
+                "required": [
+                  "boardName"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Board",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_form",
+              "title": "Create Form",
+              "description": "Create a monday.com form. This will create a new form as well as a new board for which the form’s responses will be stored. The returned board_id is the ID of the board that was created while the returned formToken can be used for all future queries and mutations to continue editing the form.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "destination_workspace_id": {
+                    "type": "string",
+                    "description": "The workspace in which the form will be created in."
+                  },
+                  "destination_folder_id": {
+                    "type": "string",
+                    "description": "The folder in which the form will be created under."
+                  },
+                  "destination_folder_name": {
+                    "type": "string",
+                    "description": "The name of the folder in which the form will be created in."
+                  },
+                  "board_kind": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "public",
+                      "share"
+                    ],
+                    "description": "The board kind to create for the board in which the form will create items in."
+                  },
+                  "destination_name": {
+                    "type": "string",
+                    "description": "The name of the board that will be created to store the form responses in."
+                  },
+                  "board_owner_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of user IDs who will have owner permissions on the board in which the form will create items in."
+                  },
+                  "board_owner_team_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of team IDs whose members will have owner permissions on the board in which the form will create items in."
+                  },
+                  "board_subscriber_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of user IDs who will receive notifications about board activity for the board in which the form will create items in."
+                  },
+                  "board_subscriber_teams_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Array of team IDs whose members will receive notifications about board activity for the board in which the form will create items in."
+                  }
+                },
+                "required": [
+                  "destination_workspace_id"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Form",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "update_form",
+              "title": "Update Form",
+              "description": "Update a monday.com form. Handles the following form update actions that can only be done one at a time using the correct \"action\" input: \n    - update form's feature settings with the action \"updateFeatures\",\n    - update form's appearance settings with the action \"updateAppearance\",\n    - update form's accessibility settings with the action \"updateAccessibility\",\n    - update form's title with the action \"updateFormHeader\",\n    - update form's description with the action \"updateFormHeader\",\n    - update form's question order with the action \"updateQuestionOrder\",\n    - create a new form tag with the action \"createTag\",\n    - delete a form tag with the action \"deleteTag\",\n    - update a form tag with the action \"updateTag\",\n    - set or update the form's password with the action \"setFormPassword\"\n    - shorten form's url with the action \"shortenFormUrl\"\n    - deactivate form with the action \"deactivateForm\"\n    - reactivate form with the action \"activateForm\"",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "formToken": {
+                    "type": "string",
+                    "description": "The unique identifier token for the form. Required for all form-specific operations."
+                  },
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "activate",
+                      "deactivate",
+                      "shortenFormUrl",
+                      "setFormPassword",
+                      "createTag",
+                      "deleteTag",
+                      "updateTag",
+                      "updateAppearance",
+                      "updateAccessibility",
+                      "updateFeatures",
+                      "updateQuestionOrder",
+                      "updateFormHeader"
+                    ],
+                    "description": "The type of update action to perform on the form. Can be one of the following: activate, deactivate, shortenFormUrl, setFormPassword, createTag, deleteTag, updateTag, updateForm, updateAppearance, updateAccessibility, updateFeatures, updateQuestionOrder, updateFormHeader."
+                  },
+                  "formPassword": {
+                    "type": "string",
+                    "description": "Set a password on a form to restrict access. This will enable password protection for the form. Required for the action \"setFormPassword\" in the update form tool."
+                  },
+                  "tag": {
+                    "type": "object",
+                    "properties": {
+                      "id": {
+                        "type": "string",
+                        "description": "The unique identifier for the tag. This will get auto generated when creating a tag and can’t be updated. This is required when updating or deleting a tag."
+                      },
+                      "name": {
+                        "type": "string",
+                        "description": "The name of the tag. This can only be created, not updated. This is required when creating a tag."
+                      },
+                      "value": {
+                        "type": "string",
+                        "description": "The value of the tag. This value is required when creating or updating a tag."
+                      },
+                      "columnId": {
+                        "type": "string",
+                        "description": "The ID of the column this tag is associated with. This will get auto generated when creating a tag and can’t be updated."
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "The tag data to create, update or delete. If deleting a tag, only provide the id of the tag to delete. If creating a tag, provide the name and value, the id and columnId are auto generated. If updating a tag, provide the id and new value, name and columnId are not changeable."
+                  },
+                  "form": {
+                    "type": "object",
+                    "properties": {
+                      "appearance": {
+                        "type": "object",
+                        "properties": {
+                          "background": {
+                            "type": "object",
+                            "properties": {
+                              "type": {
+                                "type": "string",
+                                "enum": [
+                                  "Image",
+                                  "Color",
+                                  "None"
+                                ],
+                                "description": "String specifying background style."
+                              },
+                              "value": {
+                                "type": "string",
+                                "description": "String containing the background value. The value will depend on the background type. If the background type is color, the value will be a hex color code. If the background type is image, the value will be an image URL."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing background appearance configuration for the form."
+                          },
+                          "hideBranding": {
+                            "type": "boolean",
+                            "description": "Boolean hiding monday branding from the form display."
+                          },
+                          "layout": {
+                            "type": "object",
+                            "properties": {
+                              "format": {
+                                "type": "string",
+                                "enum": [
+                                  "OneByOne",
+                                  "Classic"
+                                ],
+                                "description": "String specifying the form display format. Can be a step by step form or a classic one page form."
+                              },
+                              "alignment": {
+                                "type": "string",
+                                "enum": [
+                                  "FullLeft",
+                                  "Left",
+                                  "Center",
+                                  "Right",
+                                  "FullRight"
+                                ],
+                                "description": "String controlling text and content alignment."
+                              },
+                              "direction": {
+                                "type": "string",
+                                "enum": [
+                                  "LtR",
+                                  "Rtl"
+                                ],
+                                "description": "String setting reading direction."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing form structure and presentation settings."
+                          },
+                          "logo": {
+                            "type": "object",
+                            "properties": {
+                              "position": {
+                                "type": "string",
+                                "enum": [
+                                  "Auto",
+                                  "Left",
+                                  "Center",
+                                  "Right"
+                                ],
+                                "description": "String specifying logo placement (\"top\", \"bottom\", \"header\")."
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "Small",
+                                  "Medium",
+                                  "Large",
+                                  "ExtraLarge"
+                                ],
+                                "description": "String specifying logo size (\"small\", \"medium\", \"large\") for the logo that appears on the header of the form."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing logo display configuration for form branding."
+                          },
+                          "primaryColor": {
+                            "type": "string",
+                            "description": "Hex color code for the primary theme color used throughout the form."
+                          },
+                          "showProgressBar": {
+                            "type": "boolean",
+                            "description": "Boolean displaying a progress indicator showing form completion progress bar."
+                          },
+                          "submitButton": {
+                            "type": "object",
+                            "properties": {
+                              "text": {
+                                "type": "string",
+                                "description": "Custom text displayed on the form submission button."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing submit button styling and text configuration."
+                          },
+                          "text": {
+                            "type": "object",
+                            "properties": {
+                              "font": {
+                                "type": "string",
+                                "description": "String specifying the font family used throughout the form."
+                              },
+                              "color": {
+                                "type": "string",
+                                "description": "Hex color code for the text color in the form."
+                              },
+                              "size": {
+                                "type": "string",
+                                "enum": [
+                                  "Small",
+                                  "Medium",
+                                  "Large"
+                                ],
+                                "description": "String or number specifying the base font size for form text."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing typography and text styling configuration."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "description": "The appearance data to update. Acts as a patch object, meaning that only the fields that are provided will be updated. Required if the update action is updateAppearance."
+                      },
+                      "accessibility": {
+                        "type": "object",
+                        "properties": {
+                          "language": {
+                            "type": "string",
+                            "description": "Language code for form localization and interface text (e.g., \"en\", \"es\", \"fr\")."
+                          },
+                          "logoAltText": {
+                            "type": "string",
+                            "description": "Alternative text description for the logo image for accessibility."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "description": "The accessibility data to update. Acts as a patch object, meaning that only the fields that are provided will be updated. Required if the update action is updateAccessibility."
+                      },
+                      "features": {
+                        "type": "object",
+                        "properties": {
+                          "afterSubmissionView": {
+                            "type": "object",
+                            "properties": {
+                              "allowEditSubmission": {
+                                "type": "boolean",
+                                "description": "Boolean allowing users to modify their submitted responses after submission."
+                              },
+                              "allowResubmit": {
+                                "type": "boolean",
+                                "description": "Boolean allowing users to submit multiple responses to the same form."
+                              },
+                              "allowViewSubmission": {
+                                "type": "boolean",
+                                "description": "Boolean allowing users to view their submitted responses."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Text shown to users after they complete the form."
+                              },
+                              "redirectAfterSubmission": {
+                                "type": "object",
+                                "properties": {
+                                  "enabled": {
+                                    "type": "boolean",
+                                    "description": "Boolean enabling automatic redirect after form completion to a specified URL."
+                                  },
+                                  "redirectUrl": {
+                                    "type": "string",
+                                    "description": "The URL where users will be redirected after successfully submitting the form."
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "description": "Object containing redirect configuration after form submission."
+                              },
+                              "showSuccessImage": {
+                                "type": "boolean",
+                                "description": "Boolean displaying a success image after form completion."
+                              },
+                              "title": {
+                                "type": "string",
+                                "description": "Text displayed as the title after successful form submission."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing settings for the post-submission user experience."
+                          },
+                          "closeDate": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Boolean enabling automatic form closure at a specified date and time."
+                              },
+                              "date": {
+                                "type": "string",
+                                "description": "ISO timestamp when the form will automatically stop accepting responses."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing automatic form closure configuration."
+                          },
+                          "draftSubmission": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Boolean allowing users to save incomplete responses as drafts."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing draft saving configuration allowing users to save progress."
+                          },
+                          "monday": {
+                            "type": "object",
+                            "properties": {
+                              "itemGroupId": {
+                                "type": "string",
+                                "description": "The board group ID where new items from form responses will be created."
+                              },
+                              "includeNameQuestion": {
+                                "type": "boolean",
+                                "description": "Boolean adding a name question to the form. This is a special question type that represents the name column from the associated monday board"
+                              },
+                              "includeUpdateQuestion": {
+                                "type": "boolean",
+                                "description": "Boolean adding an update/comment field to the form. This is a special question type that represents the updates from the associated item of the submission on the monday board. "
+                              },
+                              "syncQuestionAndColumnsTitles": {
+                                "type": "boolean",
+                                "description": "Boolean synchronizing form question titles with board column names. When true, the form question titles will be synchronized with the board column names."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing board settings for response handling."
+                          },
+                          "password": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Boolean disabling password protection. Can only be updated to false. In order to enable password protection use the setFormPassword action instead."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing password protection configuration for the form."
+                          },
+                          "preSubmissionView": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Boolean showing a welcome/introduction screen before the form begins."
+                              },
+                              "title": {
+                                "type": "string",
+                                "description": "Text displayed as the title on the welcome screen."
+                              },
+                              "description": {
+                                "type": "string",
+                                "description": "Text providing context or instructions on the welcome screen."
+                              },
+                              "startButton": {
+                                "type": "object",
+                                "properties": {
+                                  "text": {
+                                    "type": "string",
+                                    "description": "Custom text for the button that begins the form experience."
+                                  }
+                                },
+                                "additionalProperties": false,
+                                "description": "Object containing start button configuration for the welcome screen."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing welcome screen configuration displayed before the form."
+                          },
+                          "reCaptchaChallenge": {
+                            "type": "boolean",
+                            "description": "Boolean enabling reCAPTCHA verification to prevent spam submissions."
+                          },
+                          "requireLogin": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Boolean requiring users to be logged in before submitting responses."
+                              },
+                              "redirectToLogin": {
+                                "type": "boolean",
+                                "description": "Boolean automatically redirecting unauthenticated users to the login page."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing login requirement settings for form access."
+                          },
+                          "responseLimit": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Boolean enabling response count limits for the form."
+                              },
+                              "limit": {
+                                "type": "number",
+                                "description": "Integer specifying the maximum number of responses allowed."
+                              }
+                            },
+                            "additionalProperties": false,
+                            "description": "Object containing response limitation settings to control submission volume."
+                          }
+                        },
+                        "additionalProperties": false,
+                        "description": "The features data to update. Acts as a patch object, meaning that only the fields that are provided will be updated. Required if the update action is updateFeatures."
+                      },
+                      "title": {
+                        "type": "string",
+                        "description": "The title text for the form. Must be at least 1 character long. Can only be updated if the update action is updateFormHeader."
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Optional description text providing context about the form purpose. Can only be updated if the update action is updateFormHeader."
+                      },
+                      "questions": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "id": {
+                              "type": "string",
+                              "description": "The unique identifier for the question. Used to target specific questions within a form. Required when deleting or updating a question."
+                            }
+                          },
+                          "required": [
+                            "id"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "description": "Ordered array of dehydrated questions, object only including each question ID, for reordering. Must include all existing question IDs. Required if the update action is updateQuestionOrder."
+                      }
+                    },
+                    "additionalProperties": false,
+                    "description": "The form data to update. Required if updating the appearance, accessibility, features, question order, or form header."
+                  }
+                },
+                "required": [
+                  "formToken",
+                  "action"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Update Form",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_form",
+              "title": "Get Form",
+              "description": "Get a monday.com form by its form token. Form tokens can be extracted from the form’s url. Given a form url, such as https://forms.monday.com/forms/abc123def456ghi789?r=use1, the token is the alphanumeric string that appears right after /forms/ and before the ?. In the example, the token is abc123def456ghi789.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "formToken": {
+                    "type": "string",
+                    "description": "The unique identifier token for the form. Required for all form-specific operations."
+                  }
+                },
+                "required": [
+                  "formToken"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Form",
+                "readOnlyHint": true,
+                "destructiveHint": false
+              }
+            },
+            {
+              "name": "form_questions_editor",
+              "title": "Form Questions Editor",
+              "description": "Create, update, or delete a question in a monday.com form",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "action": {
+                    "type": "string",
+                    "enum": [
+                      "delete",
+                      "update",
+                      "create"
+                    ],
+                    "description": "The type of operation to perform on the question. Can delete, update, or create. When updating or deleting a question, the questionId is required. When creating or updating a question, the question object is required. When updating, the question is a patch object, meaning that only the fields that are provided will be updated."
+                  },
+                  "formToken": {
+                    "type": "string",
+                    "description": "The unique identifier token for the form. Required for all form-specific operations."
+                  },
+                  "questionId": {
+                    "type": "string",
+                    "description": "The unique identifier for the question. Used to target specific questions within a form."
+                  },
+                  "question": {
+                    "type": "object",
+                    "properties": {
+                      "type": {
+                        "type": "string",
+                        "enum": [
+                          "Boolean",
+                          "ConnectedBoards",
+                          "Country",
+                          "Date",
+                          "DateRange",
+                          "Email",
+                          "File",
+                          "Link",
+                          "Location",
+                          "LongText",
+                          "MultiSelect",
+                          "Name",
+                          "Number",
+                          "People",
+                          "Phone",
+                          "Rating",
+                          "ShortText",
+                          "Signature",
+                          "SingleSelect",
+                          "Subitems",
+                          "Updates"
+                        ],
+                        "description": "The question type determining input behavior and validation (e.g., \"text\", \"email\", \"single_select\", \"multi_select\")."
+                      },
+                      "title": {
+                        "type": "string",
+                        "description": "The question text displayed to respondents. Must be at least 1 character long and clearly indicate the expected response."
+                      },
+                      "description": {
+                        "type": "string",
+                        "description": "Optional explanatory text providing additional context, instructions, or examples for the question."
+                      },
+                      "visible": {
+                        "type": "boolean",
+                        "description": "Boolean controlling question visibility to respondents. Hidden questions remain in form structure but are not displayed."
+                      },
+                      "required": {
+                        "type": "boolean",
+                        "description": "Boolean indicating if the question must be answered before form submission."
+                      },
+                      "options": {
+                        "type": "array",
+                        "items": {
+                          "type": "object",
+                          "properties": {
+                            "label": {
+                              "type": "string",
+                              "description": "The display text for individual option choices in select-type questions."
+                            }
+                          },
+                          "required": [
+                            "label"
+                          ],
+                          "additionalProperties": false
+                        },
+                        "description": "Array of option objects for choice-based questions (single_select, multi_select). Required when creating select type questions. Can only be provided when creating a question, not yet supported for updating a question."
+                      },
+                      "settings": {
+                        "type": "object",
+                        "properties": {
+                          "checkedByDefault": {
+                            "type": "boolean",
+                            "description": "Boolean/checkbox questions only: Whether the checkbox should be checked by default when the form loads."
+                          },
+                          "defaultCurrentDate": {
+                            "type": "boolean",
+                            "description": "Date based questions only: Automatically set the current date as the default value when the form loads."
+                          },
+                          "display": {
+                            "type": "string",
+                            "enum": [
+                              "Dropdown",
+                              "Horizontal",
+                              "Vertical"
+                            ],
+                            "description": "Single/Multi Select questions only: Controls how the selection options are visually presented to users."
+                          },
+                          "includeTime": {
+                            "type": "boolean",
+                            "description": "Date questions only: Whether to include time selection (hours and minutes) in addition to the date picker. When false, only date selection is available."
+                          },
+                          "locationAutofilled": {
+                            "type": "boolean",
+                            "description": "Location questions only: Automatically detect and fill the user's current location using browser geolocation services, requiring user permission."
+                          },
+                          "optionsOrder": {
+                            "type": "string",
+                            "enum": [
+                              "Alphabetical",
+                              "Custom",
+                              "Random"
+                            ],
+                            "description": "Single/Multi Select questions only: Determines the ordering of selection options."
+                          },
+                          "prefixAutofilled": {
+                            "type": "boolean",
+                            "description": "Phone questions only: Automatically detect and fill the phone country prefix based on the user's geographic location or browser settings."
+                          },
+                          "prefixPredefined": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Whether a predefined phone prefix is enabled for phone number questions. When true, the specified prefix will be pre-selected."
+                              },
+                              "prefix": {
+                                "type": "string",
+                                "description": "The predefined phone country prefix to use as country code in capital letters (e.g., \"US\", \"UK\", \"IL\"). Only used when enabled is true."
+                              }
+                            },
+                            "required": [
+                              "enabled"
+                            ],
+                            "additionalProperties": false,
+                            "description": "Phone questions only: Configuration for setting a specific predefined phone country prefix that will be pre-selected for users."
+                          },
+                          "skipValidation": {
+                            "type": "boolean",
+                            "description": "Link/URL questions only: Whether to skip URL format validation, allowing any text input."
+                          },
+                          "prefill": {
+                            "type": "object",
+                            "properties": {
+                              "enabled": {
+                                "type": "boolean",
+                                "description": "Whether prefill functionality is enabled for this question. When true, the question will attempt to auto-populate values from the specified source."
+                              },
+                              "lookup": {
+                                "type": "string",
+                                "description": "The specific field or parameter name to lookup from the prefill source. For account sources, this would be a user property like \"name\" or \"email\". For query parameters, this would be the parameter name that would be set in the URL."
+                              },
+                              "source": {
+                                "type": "string",
+                                "enum": [
+                                  "Account",
+                                  "QueryParam"
+                                ],
+                                "description": "The data source to use for prefilling the question value. Check the PrefillSources for available options."
+                              }
+                            },
+                            "required": [
+                              "enabled"
+                            ],
+                            "additionalProperties": false,
+                            "description": "Configuration for automatically populating question values from various data sources such as user account information or URL query parameters."
+                          }
+                        },
+                        "additionalProperties": false
+                      }
+                    },
+                    "required": [
+                      "type"
+                    ],
+                    "additionalProperties": false,
+                    "description": "The question object containing all properties for creation or update. When creating a question, the title is required."
+                  }
+                },
+                "required": [
+                  "action",
+                  "formToken"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Form Questions Editor",
+                "readOnlyHint": false,
+                "destructiveHint": true,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_column",
+              "title": "Create Column",
+              "description": "Create a new column in a monday.com board",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to which the new column will be added"
+                  },
+                  "columnType": {
+                    "type": "string",
+                    "enum": [
+                      "auto_number",
+                      "board_relation",
+                      "button",
+                      "checkbox",
+                      "color_picker",
+                      "country",
+                      "creation_log",
+                      "date",
+                      "dependency",
+                      "direct_doc",
+                      "doc",
+                      "dropdown",
+                      "email",
+                      "file",
+                      "formula",
+                      "group",
+                      "hour",
+                      "integration",
+                      "item_assignees",
+                      "item_id",
+                      "last_updated",
+                      "link",
+                      "location",
+                      "long_text",
+                      "mirror",
+                      "name",
+                      "numbers",
+                      "people",
+                      "phone",
+                      "progress",
+                      "rating",
+                      "status",
+                      "subtasks",
+                      "tags",
+                      "team",
+                      "text",
+                      "time_tracking",
+                      "timeline",
+                      "unsupported",
+                      "vote",
+                      "week",
+                      "world_clock"
+                    ],
+                    "description": "The type of the column to be created"
+                  },
+                  "columnTitle": {
+                    "type": "string",
+                    "description": "The title of the column to be created"
+                  },
+                  "columnDescription": {
+                    "type": "string",
+                    "description": "The description of the column to be created"
+                  },
+                  "columnSettings": {
+                    "type": "string",
+                    "description": "Column-specific configuration settings as a JSON string. Use the get_column_type_info tool to fetch the JSON schema for the given column type."
+                  }
+                },
+                "required": [
+                  "boardId",
+                  "columnType",
+                  "columnTitle"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Column",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_group",
+              "title": "Create Group",
+              "description": "Create a new group in a monday.com board. Groups are sections that organize related items. Use when users want to add structure, categorize items, or create workflow phases. Groups can be positioned relative to existing groups and assigned predefined colors. Items will always be created in the top group and so the top group should be the most relevant one for new item creation",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "string",
+                    "description": "The ID of the board to create the group in"
+                  },
+                  "groupName": {
+                    "type": "string",
+                    "maxLength": 255,
+                    "description": "The name of the new group (maximum 255 characters)"
+                  },
+                  "groupColor": {
+                    "type": "string",
+                    "enum": [
+                      "#037f4c",
+                      "#00c875",
+                      "#9cd326",
+                      "#cab641",
+                      "#ffcb00",
+                      "#784bd1",
+                      "#9d50dd",
+                      "#007eb5",
+                      "#579bfc",
+                      "#66ccff",
+                      "#bb3354",
+                      "#df2f4a",
+                      "#ff007f",
+                      "#ff5ac4",
+                      "#ff642e",
+                      "#fdab3d",
+                      "#7f5347",
+                      "#c4c4c4",
+                      "#757575"
+                    ],
+                    "description": "The color for the group. Must be one of the predefined Monday.com group colors: #037f4c, #00c875, #9cd326, #cab641, #ffcb00, #784bd1, #9d50dd, #007eb5, #579bfc, #66ccff, #bb3354, #df2f4a, #ff007f, #ff5ac4, #ff642e, #fdab3d, #7f5347, #c4c4c4, #757575"
+                  },
+                  "relativeTo": {
+                    "type": "string",
+                    "description": "The ID of the group to position this new group relative to"
+                  },
+                  "positionRelativeMethod": {
+                    "type": "string",
+                    "enum": [
+                      "after_at",
+                      "before_at"
+                    ],
+                    "description": "Whether to position the new group before or after the relativeTo group"
+                  }
+                },
+                "required": [
+                  "boardId",
+                  "groupName"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Group",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "delete_column",
+              "title": "Delete Column",
+              "description": "Delete a column from a monday.com board",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to which the new column will be added"
+                  },
+                  "columnId": {
+                    "type": "string",
+                    "description": "The id of the column to be deleted"
+                  }
+                },
+                "required": [
+                  "boardId",
+                  "columnId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Delete Column",
+                "readOnlyHint": false,
+                "destructiveHint": true,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "get_column_type_info",
+              "title": "Get Column Type Info",
+              "description": "Retrieves comprehensive information about a specific column type, including JSON schema definition and other metadata. Use this before creating columns with the create_column tool to understand the structure, validation rules, and available properties for column settings.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "columnType": {
+                    "type": "string",
+                    "enum": [
+                      "auto_number",
+                      "board_relation",
+                      "button",
+                      "checkbox",
+                      "color_picker",
+                      "country",
+                      "creation_log",
+                      "date",
+                      "dependency",
+                      "direct_doc",
+                      "doc",
+                      "dropdown",
+                      "email",
+                      "file",
+                      "formula",
+                      "group",
+                      "hour",
+                      "integration",
+                      "item_assignees",
+                      "item_id",
+                      "last_updated",
+                      "link",
+                      "location",
+                      "long_text",
+                      "mirror",
+                      "name",
+                      "numbers",
+                      "people",
+                      "phone",
+                      "progress",
+                      "rating",
+                      "status",
+                      "subtasks",
+                      "tags",
+                      "team",
+                      "text",
+                      "time_tracking",
+                      "timeline",
+                      "unsupported",
+                      "vote",
+                      "week",
+                      "world_clock"
+                    ],
+                    "description": "The column type to retrieve information for (e.g., \"text\", \"status\", \"date\", \"numbers\")"
+                  }
+                },
+                "required": [
+                  "columnType"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Column Type Info",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_custom_activity",
+              "title": "Create Custom Activity",
+              "description": "Create a new custom activity in the E&A app",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "color": {
+                    "type": "string",
+                    "enum": [
+                      "BRINK_PINK",
+                      "CELTIC_BLUE",
+                      "CORNFLOWER_BLUE",
+                      "DINGY_DUNGEON",
+                      "GO_GREEN",
+                      "GRAY",
+                      "LIGHT_DEEP_PINK",
+                      "LIGHT_HOT_PINK",
+                      "MAYA_BLUE",
+                      "MEDIUM_TURQUOISE",
+                      "PARADISE_PINK",
+                      "PHILIPPINE_GREEN",
+                      "PHILIPPINE_YELLOW",
+                      "SLATE_BLUE",
+                      "VIVID_CERULEAN",
+                      "YANKEES_BLUE",
+                      "YELLOW_GREEN",
+                      "YELLOW_ORANGE"
+                    ],
+                    "description": "The color of the custom activity"
+                  },
+                  "icon_id": {
+                    "type": "string",
+                    "enum": [
+                      "ASCENDING",
+                      "CAMERA",
+                      "CONFERENCE",
+                      "FLAG",
+                      "GIFT",
+                      "HEADPHONES",
+                      "HOMEKEYS",
+                      "LOCATION",
+                      "NOTEBOOK",
+                      "PAPERPLANE",
+                      "PLANE",
+                      "PLIERS",
+                      "TRIPOD",
+                      "TWOFLAGS",
+                      "UTENCILS"
+                    ],
+                    "description": "The icon ID of the custom activity"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the custom activity"
+                  }
+                },
+                "required": [
+                  "color",
+                  "icon_id",
+                  "name"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Custom Activity",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_notification",
+              "title": "Create Notification",
+              "description": "Send a notification to a user via the bell icon and optionally by email. Use target_type \"Post\" for updates/replies or \"Project\" for items/boards.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "user_id": {
+                    "type": "string",
+                    "description": "The user ID to send the notification to"
+                  },
+                  "target_id": {
+                    "type": "string",
+                    "description": "The target ID (update/reply ID for Post type, item/board ID for Project type)"
+                  },
+                  "text": {
+                    "type": "string",
+                    "description": "The notification text"
+                  },
+                  "target_type": {
+                    "type": "string",
+                    "enum": [
+                      "Post",
+                      "Project"
+                    ],
+                    "description": "The target type (Post for update/reply, Project for item/board)"
+                  }
+                },
+                "required": [
+                  "user_id",
+                  "target_id",
+                  "text",
+                  "target_type"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Notification",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_timeline_item",
+              "title": "Create Timeline Item",
+              "description": "Create a new timeline item in the E&A app",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "item_id": {
+                    "type": "number",
+                    "description": "The ID of the item to create the new timeline item on"
+                  },
+                  "custom_activity_id": {
+                    "type": "string",
+                    "description": "The ID of the custom activity for the timeline item"
+                  },
+                  "title": {
+                    "type": "string",
+                    "description": "The title of the new timeline item"
+                  },
+                  "summary": {
+                    "type": "string",
+                    "description": "The summary of the new timeline item (max 255 characters)"
+                  },
+                  "content": {
+                    "type": "string",
+                    "description": "The content of the new timeline item"
+                  },
+                  "timestamp": {
+                    "type": "string",
+                    "description": "The creation time of the new timeline item in ISO8601 format (e.g., 2024-06-06T18:00:30Z)"
+                  },
+                  "start_timestamp": {
+                    "type": "string",
+                    "description": "The start time of the timeline item in ISO8601 format"
+                  },
+                  "end_timestamp": {
+                    "type": "string",
+                    "description": "The end time of the timeline item in ISO8601 format"
+                  },
+                  "location": {
+                    "type": "string",
+                    "description": "The location to add to the new timeline item"
+                  },
+                  "phone": {
+                    "type": "string",
+                    "description": "The phone number to add to the new timeline item"
+                  },
+                  "url": {
+                    "type": "string",
+                    "description": "The URL to add to the new timeline item"
+                  }
+                },
+                "required": [
+                  "item_id",
+                  "custom_activity_id",
+                  "title",
+                  "timestamp"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Timeline Item",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "fetch_custom_activity",
+              "title": "Fetch Custom Activities",
+              "description": "Get custom activities from the E&A app",
+              "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Fetch Custom Activities",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "read_docs",
+              "title": "Read Documents",
+              "description": "Get a collection of monday.com documents with their content as markdown. \n\nPAGINATION: \n- Default limit is 25 documents per page\n- Use 'page' parameter to get additional pages (starts at 1)\n- Check response for 'has_more_pages' to know if you should continue paginating\n- If user asks for \"all documents\" and you get exactly 25 results, continue with page 2, 3, etc.\n\nFILTERING: Provide a type value and array of ids:\n- type: 'ids' for specific document IDs\n- type: 'object_ids' for specific document object IDs  \n- type: 'workspace_ids' for all docs in specific workspaces\n- ids: array of ID strings (at least 1 required)\n\nExamples:\n- { type: 'ids', ids: ['123', '456'] }\n- { type: 'object_ids', ids: ['123'] }\n- { type: 'workspace_ids', ids: ['ws_101'] }\n\nUSAGE PATTERNS:\n- For specific documents: use type 'ids' or 'object_ids' (A monday doc has two unique identifiers)\n- For workspace exploration: use type 'workspace_ids' with pagination\n- For large searches: start with page 1, then paginate if has_more_pages=true",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "type": {
+                    "type": "string",
+                    "enum": [
+                      "ids",
+                      "object_ids",
+                      "workspace_ids"
+                    ],
+                    "description": "Query type of ids parameter that is used query by: ids, object_ids, or workspace_ids"
+                  },
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "Array of ID values for this query type (at least 1 required)"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "description": "Number of docs per page (default: 25). Affects pagination - if you get exactly this many results, there may be more pages."
+                  },
+                  "order_by": {
+                    "type": "string",
+                    "enum": [
+                      "created_at",
+                      "used_at"
+                    ],
+                    "description": "The order in which to retrieve your docs. The default shows created_at with the newest docs listed first. This argument will not be applied if you query docs by specific ids."
+                  },
+                  "page": {
+                    "type": "number",
+                    "description": "The page number to return (starts at 1). Use this to paginate through large result sets. Check response for has_more_pages indicator."
+                  }
+                },
+                "required": [
+                  "type",
+                  "ids"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Read Documents",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "workspace_info",
+              "title": "Get Workspace Information",
+              "description": "This tool returns the boards, docs and folders in a workspace and which folder they are in. It returns up to 100 of each object type, if you receive 100 assume there are additional objects of that type in the workspace.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "workspace_id": {
+                    "type": "number",
+                    "description": "The ID of the workspace to get information for"
+                  }
+                },
+                "required": [
+                  "workspace_id"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Workspace Information",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "list_workspaces",
+              "title": "List Workspaces",
+              "description": "List all workspaces available to the user. Returns up to 500 workspaces with their ID, name, and description.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "searchTerm": {
+                    "type": "string",
+                    "description": "Optional search term used to filter workspaces. [IMPORANT] Only alphanumeric characters are supported."
+                  },
+                  "limit": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 100,
+                    "description": "Number of workspaces to return. Set to max (100) lower for smaller response size"
+                  },
+                  "page": {
+                    "type": "number",
+                    "minimum": 1,
+                    "default": 1,
+                    "description": "Page number to return. Default is 1."
+                  }
+                },
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "List Workspaces",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_doc",
+              "title": "Create Document",
+              "description": "Create a new monday.com doc either inside a workspace or attached to an item (via a doc column). After creation, the provided markdown will be appended to the document.\n\nLOCATION TYPES:\n- workspace: Creates a document in a workspace (requires workspace_id, optional doc_kind, optional folder_id)\n- item: Creates a document attached to an item (requires item_id, optional column_id)\n\nUSAGE EXAMPLES:\n- Workspace doc: { location: \"workspace\", workspace_id: 123, doc_kind: \"private\" , markdown: \"...\" }\n- Workspace doc in folder: { location: \"workspace\", workspace_id: 123, folder_id: 17264196 , markdown: \"...\" }\n- Item doc: { location: \"item\", item_id: 456, column_id: \"doc_col_1\" , markdown: \"...\" }",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "doc_name": {
+                    "type": "string",
+                    "description": "Name for the new document."
+                  },
+                  "markdown": {
+                    "type": "string",
+                    "description": "Markdown content that will be imported into the newly created document as blocks."
+                  },
+                  "location": {
+                    "type": "string",
+                    "enum": [
+                      "workspace",
+                      "item"
+                    ],
+                    "description": "Location where the document should be created - either in a workspace or attached to an item"
+                  },
+                  "workspace_id": {
+                    "type": "number",
+                    "description": "[REQUIRED - use only when location=\"workspace\"] Workspace ID under which to create the new document"
+                  },
+                  "doc_kind": {
+                    "type": "string",
+                    "enum": [
+                      "private",
+                      "public",
+                      "share"
+                    ],
+                    "description": "[OPTIONAL - use only when location=\"workspace\"] Document kind (public/private/share). Defaults to public."
+                  },
+                  "folder_id": {
+                    "type": "number",
+                    "description": "[OPTIONAL - use only when location=\"workspace\"] Optional folder ID to place the document inside a specific folder"
+                  },
+                  "item_id": {
+                    "type": "number",
+                    "description": "[REQUIRED - use only when location=\"item\"] Item ID to attach the new document to"
+                  },
+                  "column_id": {
+                    "type": "string",
+                    "description": "[OPTIONAL - use only when location=\"item\"] ID of an existing \"doc\" column on the board which contains the item. If not provided, the tool will create a new doc column automatically when creating a doc on an item."
+                  }
+                },
+                "required": [
+                  "doc_name",
+                  "markdown",
+                  "location"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Document",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "add_content_to_doc",
+              "title": "Add Content to Document",
+              "description": "Add markdown content to an existing monday.com document.\n\nIDENTIFICATION: Provide either doc_id or object_id to identify the document:\n- doc_id: The document ID (the id field returned by read_docs). Takes priority if both provided.\n- object_id: The document object ID (the object_id field from read_docs, also visible in the document URL). Will be resolved to a doc_id.\n\nUSAGE EXAMPLES:\n- By doc_id: { doc_id: \"123\", markdown: \"# New Section\\nContent here\" }\n- By object_id: { object_id: \"456\", markdown: \"# New Section\\nContent here\" }\n- Insert after block: { doc_id: \"123\", markdown: \"Inserted content\", after_block_id: \"block_789\" }",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "doc_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The document ID (the id field returned by read_docs). Provide this OR object_id. Takes priority if both are provided."
+                  },
+                  "object_id": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "The document object ID (the object_id field from read_docs, also visible in the document URL). Will be resolved to a doc_id. Provide this OR doc_id."
+                  },
+                  "markdown": {
+                    "type": "string",
+                    "description": "Markdown content to add to the document."
+                  },
+                  "after_block_id": {
+                    "type": "string",
+                    "description": "Block ID after which to insert the new content. If omitted, content is appended at the end. To insert at the beginning, pass the first block ID from read_docs. Block IDs can be obtained from read_docs or from a previous add_content_to_doc response."
+                  }
+                },
+                "required": [
+                  "markdown"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Add Content to Document",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "update_workspace",
+              "title": "Update Workspace",
+              "description": "Update an existing workspace in monday.com",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the workspace to update"
+                  },
+                  "attributeAccountProductId": {
+                    "type": "number",
+                    "description": "The target account product's ID to move the workspace to"
+                  },
+                  "attributeDescription": {
+                    "type": "string",
+                    "description": "The description of the workspace to update"
+                  },
+                  "attributeKind": {
+                    "type": "string",
+                    "enum": [
+                      "closed",
+                      "open",
+                      "template"
+                    ],
+                    "description": "The kind of the workspace to update (open / closed / template)"
+                  },
+                  "attributeName": {
+                    "type": "string",
+                    "description": "The name of the workspace to update"
+                  }
+                },
+                "required": [
+                  "id"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Update Workspace",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "update_folder",
+              "title": "Update Folder",
+              "description": "Update an existing folder in monday.com",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "folderId": {
+                    "type": "string",
+                    "description": "The ID of the folder to update"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The new name of the folder"
+                  },
+                  "color": {
+                    "type": "string",
+                    "enum": [
+                      "AQUAMARINE",
+                      "BRIGHT_BLUE",
+                      "BRIGHT_GREEN",
+                      "CHILI_BLUE",
+                      "DARK_ORANGE",
+                      "DARK_PURPLE",
+                      "DARK_RED",
+                      "DONE_GREEN",
+                      "INDIGO",
+                      "LIPSTICK",
+                      "NULL",
+                      "PURPLE",
+                      "SOFIA_PINK",
+                      "STUCK_RED",
+                      "SUNSET",
+                      "WORKING_ORANGE"
+                    ],
+                    "description": "The new color of the folder"
+                  },
+                  "fontWeight": {
+                    "type": "string",
+                    "enum": [
+                      "FONT_WEIGHT_BOLD",
+                      "FONT_WEIGHT_LIGHT",
+                      "FONT_WEIGHT_NORMAL",
+                      "FONT_WEIGHT_VERY_LIGHT",
+                      "NULL"
+                    ],
+                    "description": "The new font weight of the folder"
+                  },
+                  "customIcon": {
+                    "type": "string",
+                    "enum": [
+                      "FOLDER",
+                      "MOREBELOW",
+                      "MOREBELOWFILLED",
+                      "NULL",
+                      "WORK"
+                    ],
+                    "description": "The new custom icon of the folder"
+                  },
+                  "parentFolderId": {
+                    "type": "string",
+                    "description": "The ID of the new parent folder"
+                  },
+                  "workspaceId": {
+                    "type": "string",
+                    "description": "The ID of the workspace containing the folder"
+                  },
+                  "accountProductId": {
+                    "type": "string",
+                    "description": "The account product ID associated with the folder"
+                  },
+                  "position_object_id": {
+                    "type": "string",
+                    "description": "The ID of the object to position the folder relative to. If this parameter is provided, position_object_type must be also provided."
+                  },
+                  "position_object_type": {
+                    "type": "string",
+                    "enum": [
+                      "Board",
+                      "Folder",
+                      "Overview"
+                    ],
+                    "description": "The type of object to position the folder relative to. If this parameter is provided, position_object_id must be also provided."
+                  },
+                  "position_is_after": {
+                    "type": "boolean",
+                    "description": "Whether to position the folder after the object"
+                  }
+                },
+                "required": [
+                  "folderId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Update Folder",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_workspace",
+              "title": "Create Workspace",
+              "description": "Create a new workspace in monday.com",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the new workspace to be created"
+                  },
+                  "workspaceKind": {
+                    "type": "string",
+                    "enum": [
+                      "closed",
+                      "open",
+                      "template"
+                    ],
+                    "description": "The kind of workspace to create"
+                  },
+                  "description": {
+                    "type": "string",
+                    "description": "The description of the new workspace"
+                  },
+                  "accountProductId": {
+                    "type": "string",
+                    "description": "The account product ID associated with the workspace"
+                  }
+                },
+                "required": [
+                  "name",
+                  "workspaceKind"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Workspace",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "create_folder",
+              "title": "Create Folder",
+              "description": "Create a new folder in a monday.com workspace",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "workspaceId": {
+                    "type": "string",
+                    "description": "The ID of the workspace where the folder will be created"
+                  },
+                  "name": {
+                    "type": "string",
+                    "description": "The name of the folder to be created"
+                  },
+                  "color": {
+                    "type": "string",
+                    "enum": [
+                      "AQUAMARINE",
+                      "BRIGHT_BLUE",
+                      "BRIGHT_GREEN",
+                      "CHILI_BLUE",
+                      "DARK_ORANGE",
+                      "DARK_PURPLE",
+                      "DARK_RED",
+                      "DONE_GREEN",
+                      "INDIGO",
+                      "LIPSTICK",
+                      "NULL",
+                      "PURPLE",
+                      "SOFIA_PINK",
+                      "STUCK_RED",
+                      "SUNSET",
+                      "WORKING_ORANGE"
+                    ],
+                    "description": "The color of the folder"
+                  },
+                  "fontWeight": {
+                    "type": "string",
+                    "enum": [
+                      "FONT_WEIGHT_BOLD",
+                      "FONT_WEIGHT_LIGHT",
+                      "FONT_WEIGHT_NORMAL",
+                      "FONT_WEIGHT_VERY_LIGHT",
+                      "NULL"
+                    ],
+                    "description": "The font weight of the folder"
+                  },
+                  "customIcon": {
+                    "type": "string",
+                    "enum": [
+                      "FOLDER",
+                      "MOREBELOW",
+                      "MOREBELOWFILLED",
+                      "NULL",
+                      "WORK"
+                    ],
+                    "description": "The custom icon of the folder"
+                  },
+                  "parentFolderId": {
+                    "type": "string",
+                    "description": "The ID of the parent folder"
+                  }
+                },
+                "required": [
+                  "workspaceId",
+                  "name"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Folder",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "move_object",
+              "title": "Move Object",
+              "description": "Move a folder, board, or overview in monday.com. Use `position` for relative placement based on another object, `parentFolderId` for folder changes, `workspaceId` for workspace moves, and `accountProductId` for account product changes.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "objectType": {
+                    "type": "string",
+                    "enum": [
+                      "Board",
+                      "Folder",
+                      "Overview"
+                    ],
+                    "description": "The type of object to move"
+                  },
+                  "id": {
+                    "type": "string",
+                    "description": "The ID of the object to move"
+                  },
+                  "position_object_id": {
+                    "type": "string",
+                    "description": "The ID of the object to position the object relative to. If this parameter is provided, position_object_type must be also provided."
+                  },
+                  "position_object_type": {
+                    "type": "string",
+                    "enum": [
+                      "Board",
+                      "Folder",
+                      "Overview"
+                    ],
+                    "description": "The type of object to position the object relative to. If this parameter is provided, position_object_id must be also provided."
+                  },
+                  "position_is_after": {
+                    "type": "boolean",
+                    "description": "Whether to position the object after the object"
+                  },
+                  "parentFolderId": {
+                    "type": "string",
+                    "description": "The ID of the new parent folder. Required if moving to a different folder."
+                  },
+                  "workspaceId": {
+                    "type": "string",
+                    "description": "The ID of the workspace containing the object. Required if moving to a different workspace."
+                  },
+                  "accountProductId": {
+                    "type": "string",
+                    "description": "The ID of the account product containing the object. Required if moving to a different account product."
+                  }
+                },
+                "required": [
+                  "objectType",
+                  "id"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Move Object",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_dashboard",
+              "title": "Create Dashboard",
+              "description": "Use this tool to create a new monday.com dashboard that aggregates data from one or more boards. \n    Dashboards provide visual representations of board data through widgets and charts.\n    \n    Use this tool when users want to:\n    - Create a dashboard to visualize board data\n    - Aggregate information from multiple boards\n    - Set up a data visualization container for widgets",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Human-readable dashboard title (UTF-8 chars)"
+                  },
+                  "workspace_id": {
+                    "type": "string",
+                    "description": "ID of the workspace that will own the dashboard"
+                  },
+                  "board_ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "minItems": 1,
+                    "maxItems": 50,
+                    "description": "List of board IDs as strings (min 1 element)"
+                  },
+                  "kind": {
+                    "type": "string",
+                    "enum": [
+                      "PRIVATE",
+                      "PUBLIC"
+                    ],
+                    "default": "PUBLIC",
+                    "description": "Visibility level: PUBLIC or PRIVATE"
+                  },
+                  "board_folder_id": {
+                    "type": "string",
+                    "description": "Optional folder ID within workspace to place this dashboard (if not provided, dashboard will be placed in workspace root)"
+                  }
+                },
+                "required": [
+                  "name",
+                  "workspace_id",
+                  "board_ids"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Dashboard",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "all_widgets_schema",
+              "title": "Get All Widget Schemas",
+              "description": "Fetch complete JSON Schema 7 definitions for all available widget types in monday.com.\n    \n    This tool is essential before creating widgets as it provides:\n    - Complete schema definitions for all supported widgets\n    - Required and optional fields for each widget type\n    - Data type specifications and validation rules\n    - Detailed descriptions of widget capabilities\n    \n    Use this tool when you need to:\n    - Understand widget configuration requirements before creating widgets\n    - Validate widget settings against official schemas\n    - Plan widget implementations with proper data structures\n    \n    The response includes JSON Schema 7 definitions that describe exactly what settings each widget type accepts.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get All Widget Schemas",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "create_widget",
+              "title": "Create Widget",
+              "description": "Create a new widget in a dashboard or board view with specific configuration settings.\n    \n    This tool creates data visualization widgets that display information from monday.com boards:\n    **Parent Containers:**\n    - **DASHBOARD**: Place widget in a dashboard (most common use case)\n    - **BOARD_VIEW**: Place widget in a specific board view\n    \n    **Critical Requirements:**\n    1. **Schema Compliance**: Widget settings MUST conform to the JSON schema for the specific widget type\n    2. **Use all_widgets_schema first**: Always fetch widget schemas before creating widgets\n    3. **Validate settings**: Ensure all required fields are provided and data types match\n    \n    **Workflow:**\n    1. Use 'all_widgets_schema' to get schema definitions\n    2. Prepare widget settings according to the schema\n    3. Use this tool to create the widget",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "parent_container_id": {
+                    "type": "string",
+                    "description": "ID of the parent container (dashboard ID or board view ID)"
+                  },
+                  "parent_container_type": {
+                    "type": "string",
+                    "enum": [
+                      "BOARD_VIEW",
+                      "DASHBOARD"
+                    ],
+                    "description": "Type of parent container: DASHBOARD or BOARD_VIEW"
+                  },
+                  "widget_kind": {
+                    "type": "string",
+                    "enum": [
+                      "BATTERY",
+                      "CALENDAR",
+                      "CHART",
+                      "GANTT",
+                      "NUMBER"
+                    ],
+                    "description": "Type of widget to create: i.e CHART, NUMBER, BATTERY"
+                  },
+                  "widget_name": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 255,
+                    "description": "Widget display name (1-255 UTF-8 chars)"
+                  },
+                  "settings": {
+                    "type": "object",
+                    "additionalProperties": {},
+                    "description": "Widget-specific settings as JSON object conforming to widget schema. Use all_widgets_schema tool to get the required schema for each widget type."
+                  }
+                },
+                "required": [
+                  "parent_container_id",
+                  "parent_container_type",
+                  "widget_kind",
+                  "widget_name"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Create Widget",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": false
+              }
+            },
+            {
+              "name": "board_insights",
+              "title": "Get Board Insights",
+              "description": "This tool allows you to calculate insights about board's data by filtering, grouping and aggregating columns. For example, you can get the total number of items in a board, the number of items in each status, the number of items in each column, etc. Use this tool when you need to get a summary of the board's data, for example, you want to know the total number of items in a board, the number of items in each status, the number of items in each column, etc.[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board's structure (column IDs, column types, status labels, etc.), first use get_board_info to understand the board metadata. This is essential for constructing proper filters and knowing which columns are available.[IMPORTANT]: For some columns, human-friendly label is returned inside 'LABEL_<column_id' field. E.g. for column with id 'status_123' the label is returned inside 'LABEL_status_123' field.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "number",
+                    "description": "The id of the board to get insights for"
+                  },
+                  "aggregations": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "function": {
+                          "type": "string",
+                          "enum": [
+                            "AVERAGE",
+                            "COLOR",
+                            "COUNT",
+                            "COUNT_DISTINCT",
+                            "COUNT_ITEMS",
+                            "COUNT_SUBITEMS",
+                            "DATE",
+                            "DATE_TRUNC_DAY",
+                            "DATE_TRUNC_MONTH",
+                            "DATE_TRUNC_QUARTER",
+                            "DATE_TRUNC_WEEK",
+                            "DATE_TRUNC_YEAR",
+                            "DURATION_RUNNING",
+                            "END_DATE",
+                            "EQUALS",
+                            "FIRST",
+                            "FLATTEN",
+                            "HOUR",
+                            "ID",
+                            "IS_DONE",
+                            "LABEL",
+                            "LENGTH",
+                            "LOWER",
+                            "MAX",
+                            "MEDIAN",
+                            "MIN",
+                            "MIN_MAX",
+                            "ORDER",
+                            "PERSON",
+                            "PHONE_COUNTRY_SHORT_NAME",
+                            "START_DATE",
+                            "SUM",
+                            "TRIM",
+                            "UPPER"
+                          ],
+                          "description": "The function of the aggregation. For simple column value leave undefined"
+                        },
+                        "columnId": {
+                          "type": "string",
+                          "description": "The id of the column to aggregate"
+                        }
+                      },
+                      "required": [
+                        "columnId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "The aggregations to get. Before sending the aggregations, use get_board_info tool to check \"aggregationGuidelines\" key for information. Transformative functions and plain columns (no function) must be in group by."
+                  },
+                  "groupBy": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "The columns to group by. All columns in the group by must be in the aggregations as well without a function."
+                  },
+                  "limit": {
+                    "type": "number",
+                    "maximum": 1000,
+                    "description": "The limit of the results",
+                    "default": 1000
+                  },
+                  "filters": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "columnId": {
+                          "type": "string",
+                          "description": "The id of the column to filter by"
+                        },
+                        "compareAttribute": {
+                          "type": "string",
+                          "description": "The attribute to compare the value to. This is OPTIONAL property."
+                        },
+                        "compareValue": {
+                          "anyOf": [
+                            {
+                              "type": "string"
+                            },
+                            {
+                              "type": "number"
+                            },
+                            {
+                              "type": "boolean"
+                            },
+                            {
+                              "type": "array",
+                              "items": {
+                                "type": [
+                                  "string",
+                                  "number"
+                                ]
+                              }
+                            }
+                          ],
+                          "description": "The value to compare the attribute to. This can be a string or index value depending on the column type."
+                        },
+                        "operator": {
+                          "type": "string",
+                          "enum": [
+                            "any_of",
+                            "between",
+                            "contains_terms",
+                            "contains_text",
+                            "ends_with",
+                            "greater_than",
+                            "greater_than_or_equals",
+                            "is_empty",
+                            "is_not_empty",
+                            "lower_than",
+                            "lower_than_or_equal",
+                            "not_any_of",
+                            "not_contains_text",
+                            "starts_with",
+                            "within_the_last",
+                            "within_the_next"
+                          ],
+                          "default": "any_of",
+                          "description": "The operator to use for the filter"
+                        }
+                      },
+                      "required": [
+                        "columnId",
+                        "compareValue"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "The configuration of filters to apply on the items. Before sending the filters, use get_board_info tool to check \"filteringGuidelines\" key for filtering by the column."
+                  },
+                  "filtersOperator": {
+                    "type": "string",
+                    "enum": [
+                      "and",
+                      "or"
+                    ],
+                    "default": "and",
+                    "description": "The operator to use for the filters"
+                  },
+                  "orderBy": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "columnId": {
+                          "type": "string",
+                          "description": "The id of the column to order by"
+                        },
+                        "direction": {
+                          "type": "string",
+                          "enum": [
+                            "asc",
+                            "desc"
+                          ],
+                          "default": "asc",
+                          "description": "The direction to order by"
+                        }
+                      },
+                      "required": [
+                        "columnId"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "The columns to order by, will control the order of the items in the response"
+                  }
+                },
+                "required": [
+                  "boardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Board Insights",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "search",
+              "title": "Search",
+              "description": "Search within monday.com platform. Can search for boards, documents, forms, folders.\nFor users and teams, use list_users_and_teams tool.\nFor workspaces, use list_workspaces tool.\nFor items and groups, use get_board_items_page tool.\nFor groups, use get_board_info tool.\nIMPORTANT: ids returned by this tool are prefixed with the type of the object (e.g doc-123, board-456, folder-789). When passing the ids to other tools, you need to remove the prefix and just pass the number.\n    ",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "searchTerm": {
+                    "type": "string",
+                    "description": "The search term to use for the search."
+                  },
+                  "searchType": {
+                    "type": "string",
+                    "enum": [
+                      "BOARD",
+                      "DOCUMENTS",
+                      "FOLDERS"
+                    ],
+                    "description": "The type of search to perform."
+                  },
+                  "limit": {
+                    "type": "number",
+                    "maximum": 100,
+                    "default": 100,
+                    "description": "The number of items to get. The max and default value is 100."
+                  },
+                  "page": {
+                    "type": "number",
+                    "default": 1,
+                    "description": "The page number to get. The default value is 1."
+                  },
+                  "workspaceIds": {
+                    "type": "array",
+                    "items": {
+                      "type": "number"
+                    },
+                    "description": "The ids of the workspaces to search in. [IMPORTANT] Only pass this param if user explicitly asked to search within specific workspaces."
+                  }
+                },
+                "required": [
+                  "searchType"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Search",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_user_context",
+              "title": "Get User Context",
+              "description": "Fetch current user information and their relevant items (boards, folders, workspaces, dashboards).\n    \n    Use this tool at the beginning of conversations to:\n    - Get context about who the current user is (id, name, title)\n    - Discover user's favorite boards, folders, workspaces, and dashboards\n    - Get user's most relevant boards based on visit frequency and recency\n    - Get user's most relevant people based on interaction frequency and recency\n    - Reduce the need for search requests by knowing user's commonly accessed items\n    ",
+              "inputSchema": {
+                "type": "object"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get User Context",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "update_assets_on_item",
+              "title": "Update Assets On Item",
+              "description": "Update a file or doc column value on an item using existing assets, docs, or links. Sets the column to the provided list of files, adding new ones and removing any not in the list.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "boardId": {
+                    "type": "string",
+                    "description": "The board's unique identifier"
+                  },
+                  "itemId": {
+                    "type": "string",
+                    "description": "The item's unique identifier"
+                  },
+                  "columnId": {
+                    "type": "string",
+                    "description": "The file or doc column's unique identifier"
+                  },
+                  "files": {
+                    "type": "array",
+                    "items": {
+                      "type": "object",
+                      "properties": {
+                        "fileType": {
+                          "type": "string",
+                          "enum": [
+                            "google_drive",
+                            "dropbox",
+                            "box",
+                            "onedrive",
+                            "link",
+                            "asset",
+                            "doc"
+                          ],
+                          "description": "The type of file: \"asset\" for uploaded files (requires assetId), \"doc\" for monday docs (requires objectId), \"link\" for generic links, \"google_drive\", \"dropbox\", \"box\", \"onedrive\" for cloud storage links (all link types require linkToFile)"
+                        },
+                        "name": {
+                          "type": "string",
+                          "description": "File display name"
+                        },
+                        "linkToFile": {
+                          "type": "string",
+                          "description": "File link URL. Required for link, google_drive, dropbox, box, and onedrive file types"
+                        },
+                        "assetId": {
+                          "type": "number",
+                          "description": "The asset's ID. Required when fileType is 'asset'"
+                        },
+                        "objectId": {
+                          "type": "number",
+                          "description": "The doc's ID. Required when fileType is 'doc'"
+                        }
+                      },
+                      "required": [
+                        "fileType",
+                        "name"
+                      ],
+                      "additionalProperties": false
+                    },
+                    "description": "Array of file values to set on the column"
+                  }
+                },
+                "required": [
+                  "boardId",
+                  "itemId",
+                  "columnId",
+                  "files"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Update Assets On Item",
+                "readOnlyHint": false,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_notetaker_meetings",
+              "title": "Get Notetaker Meetings",
+              "description": "Retrieve notetaker meetings with optional detailed fields. Use include_summary, include_topics, include_action_items, and include_transcript flags to control which details are returned. Supports filtering by ids, search term, and cursor-based pagination.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "ids": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    },
+                    "description": "Filter by specific meeting IDs. Use this to fetch one or more specific meetings in a single call."
+                  },
+                  "limit": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "Maximum number of notetaker meetings to return per page (1-100)."
+                  },
+                  "cursor": {
+                    "type": "string",
+                    "description": "Cursor for pagination. Use cursor from the previous page_info to fetch the next page."
+                  },
+                  "search": {
+                    "type": "string",
+                    "description": "Search notetaker meetings by title, participant name, or email."
+                  },
+                  "include_summary": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to include the AI-generated summary for each meeting."
+                  },
+                  "include_topics": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to include discussion topics and talking points for each meeting."
+                  },
+                  "include_action_items": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to include action items for each meeting."
+                  },
+                  "include_transcript": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Whether to include the full transcript for each meeting. Transcripts can be very large."
+                  }
+                },
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "Get Notetaker Meetings",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_monday_dev_sprints_boards",
+              "title": "monday-dev: Get Sprints Boards",
+              "description": "Discover monday-dev sprints boards and their associated tasks boards in your account.\n\n## Purpose:\nIdentifies and returns monday-dev sprints board IDs and tasks board IDs that you need to use with other monday-dev tools. \nThis tool scans your recently used boards (up to 100) to find valid monday-dev sprint management boards.\n\n## What it Returns:\n- Pairs of sprints boards and their corresponding tasks boards\n- Board IDs, names, and workspace information for each pair\n- The bidirectional relationship between each sprints board and its tasks board\n\n## Note:\nSearches recently used boards (up to 100). If none found, ask user to provide board IDs manually.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {},
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "monday-dev: Get Sprints Boards",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_sprints_metadata",
+              "title": "monday-dev: Get Sprints Metadata",
+              "description": "Get comprehensive sprint metadata from a monday-dev sprints board including:\n\n## Data Retrieved:\nA table of sprints with the following information:\n- Sprint ID\n- Sprint Name\n- Sprint timeline (planned from/to dates)\n- Sprint completion status (completed/in-progress/planned)\n- Sprint start date (actual)\n- Sprint end date (actual)\n- Sprint activation status\n- Sprint summary document object ID\n\n## Parameters:\n- **limit**: Number of sprints to retrieve (default: 25, max: 100)\n\nRequires the Main Sprints board ID of the monday-dev containing your sprints.",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "sprintsBoardId": {
+                    "type": "number",
+                    "description": "The ID of the monday-dev board containing the sprints"
+                  },
+                  "limit": {
+                    "type": "number",
+                    "minimum": 1,
+                    "maximum": 100,
+                    "default": 25,
+                    "description": "The number of sprints to retrieve (default: 25, max: 100)"
+                  }
+                },
+                "required": [
+                  "sprintsBoardId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "monday-dev: Get Sprints Metadata",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            },
+            {
+              "name": "get_sprint_summary",
+              "title": "monday-dev: Get Sprint Summary",
+              "description": "Get the complete summary and analysis of a sprint.\n\n## Purpose:\nUnlock deep insights into completed sprint performance. \n\nThe sprint summary content including:\n- **Scope Management**: Analysis of planned vs. unplanned tasks, scope creep\n- **Velocity & Performance**: Individual velocity, task completion rates, workload distribution per team member\n- **Task Distribution**: Breakdown of completed tasks by type (Feature, Bug, Tech Debt, Infrastructure, etc.)\n- **AI Recommendations**: Action items, process improvements, retrospective focus areas\n\n## Requirements:\n- Sprint must be completed and must be created after 1/1/2025 \n\n## Important Note:\nWhen viewing the section \"Completed by Assignee\", you'll see user IDs in the format \"@user-12345678\". the 8 digits after the @is the user ID. To retrieve the actual owner names, use the list_users_and_teams tool with the user ID and set includeTeams=false for optimal performance.\n\n",
+              "inputSchema": {
+                "type": "object",
+                "properties": {
+                  "sprintId": {
+                    "type": "number",
+                    "description": "The ID of the sprint to get the summary for (e.g., \"9123456789\")"
+                  }
+                },
+                "required": [
+                  "sprintId"
+                ],
+                "additionalProperties": false,
+                "$schema": "http://json-schema.org/draft-07/schema#"
+              },
+              "annotations": {
+                "openWorldHint": true,
+                "title": "monday-dev: Get Sprint Summary",
+                "readOnlyHint": true,
+                "destructiveHint": false,
+                "idempotentHint": true
+              }
+            }
+          ]
+        },
+        "jsonrpc": "2.0",
+        "id": 1
+      },
+      "response_is_sse": false,
+      "response_status": 200,
+      "latency_ms": 6,
+      "http_method": null,
+      "http_path": null
+    }
+  ]
+}

--- a/integration/requirements.txt
+++ b/integration/requirements.txt
@@ -1,0 +1,1 @@
+mcp-recorder>=0.4.1

--- a/integration/scenarios.yml
+++ b/integration/scenarios.yml
@@ -1,0 +1,13 @@
+schema_version: "1.0"
+
+target:
+  command: "node"
+  args: ["packages/monday-api-mcp/dist/index.js"]
+  env:
+    MONDAY_TOKEN: "test-token"
+
+scenarios:
+  list_tools:
+    description: "Capture all tool schemas, descriptions, and annotations"
+    actions:
+      - list_tools

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "dev": "turbo dev",
     "build:watch": "turbo watch build",
     "prettier": "turbo prettier",
-    "lint": "turbo lint"
+    "lint": "turbo lint",
+    "mcp:record": "mcp-recorder record-scenarios integration/scenarios.yml --output-dir integration/cassettes",
+    "mcp:verify": "mcp-recorder verify --cassette integration/cassettes/list_tools.json --target-stdio \"node packages/monday-api-mcp/dist/index.js\" --target-env MONDAY_TOKEN=test-token"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.29.0",


### PR DESCRIPTION
**[POC]** Adds regression test coverage for MCP tool schemas using [mcp-recorder](https://github.com/devhelmhq/mcp-recorder) -- like VCR.py but for MCP servers. Records the full protocol exchange into a JSON cassette and verifies it hasn't changed on every PR.

## Why this matters

The MCP server exposes 20+ tools to AI agents. The tool names, descriptions, input schemas, and annotations **are the contract** -- when they drift, downstream agents break silently. Today there's no test that catches "someone changed a `.describe()` string" or "a tool got accidentally filtered out."

## What this covers

A single cassette (`list_tools.json`, ~3200 lines) captures 3 interactions:

- **Protocol handshake** -- `initialize` response with protocol version, capabilities, server info
- **Tool schemas** -- `tools/list` with complete input schemas, descriptions, and annotations for all registered tools

If a tool is renamed, a parameter is removed, a description changes, or an annotation flips, the CI diff shows exactly what broke.

## How it works

The server is spawned via stdio with `MONDAY_TOKEN=test-token`. The token is never validated for `initialize` + `tools/list` -- these only enumerate the in-memory tool registry. No network calls, no secrets, no real API access needed.

## Why this is a POC

This PR adds a Python dependency (`mcp-recorder`) to a TypeScript repo, so it may not fit the project's tooling preferences. However, it demonstrates the benefits of a snapshot-based testing:

- **Schema drift detection is cheap** -- one YAML file, one cassette, zero secrets
- **The cassette diff is the review** -- any tool schema change shows up as a JSON diff in the PR, making it explicit and reviewable
- **The full tool surface captured** -- the committed cassette serves as living documentation of every tool's public interface

## Changes

All additive -- only `.github/workflows/pull_request.yml` and `package.json` modified.

```
integration/
  scenarios.yml                      # list_tools scenario in ~14 lines of YAML
  cassettes/list_tools.json          # golden cassette (3 interactions, ~3200 lines)
  requirements.txt                   # mcp-recorder>=0.4.1
.github/workflows/pull_request.yml   # CI: verify step after build
package.json                         # mcp:record and mcp:verify convenience scripts
```

## Run locally

```bash
pip install -r integration/requirements.txt
yarn build

mcp-recorder verify \
  --cassette integration/cassettes/list_tools.json \
  --target-stdio "node packages/monday-api-mcp/dist/index.js" \
  --target-env MONDAY_TOKEN=test-token
```

## Update after intentional changes

```bash
yarn build
mcp-recorder verify \
  --cassette integration/cassettes/list_tools.json \
  --target-stdio "node packages/monday-api-mcp/dist/index.js" \
  --target-env MONDAY_TOKEN=test-token \
  --update
```

The cassette diff in the PR review shows exactly what changed in the tool surface.