### PR TITLE
fix(create-doc): preserve created docs when markdown import fails

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.test.ts
@@ -5,7 +5,7 @@ import { BoardKind } from 'src/monday-graphql/generated/graphql/graphql';
 import { z, ZodTypeAny } from 'zod';
 import { NonDeprecatedColumnType } from 'src/utils/types';
 
-export type inputType = z.objectInputType<typeof createDocToolSchema, ZodTypeAny>;
+type inputType = z.objectInputType<typeof createDocToolSchema, ZodTypeAny>;
 
 describe('CreateDocTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
@@ -301,9 +301,55 @@ describe('CreateDocTool', () => {
 
         const result = await callToolByNameRawAsync('create_doc', args);
 
-        expect(result.content[0].text).toContain('Document doc_789 created');
-        expect(result.content[0].text).toContain('failed to add markdown content');
-        expect(result.content[0].text).toContain('Invalid markdown format');
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+          message: 'Document created, but failed to add markdown content',
+          doc_id: 'doc_789',
+          object_id: 'obj_789',
+          doc_url: 'https://monday.com/docs/obj_789',
+          doc_name: 'Test Document',
+          markdown_content_added: false,
+          markdown_content_error: 'Invalid markdown format',
+        });
+      });
+
+      it('should return partial success when addContentToDocFromMarkdown throws after document creation', async () => {
+        const createDocResponse = {
+          create_doc: {
+            id: 'doc_790',
+            object_id: 'obj_790',
+            url: 'https://monday.com/docs/obj_790',
+            name: 'Test Document',
+          },
+        };
+
+        jest.spyOn(mocks, 'mockRequest').mockImplementation((query: string) => {
+          if (query.includes('mutation createDoc')) {
+            return Promise.resolve(createDocResponse);
+          }
+          if (query.includes('mutation addContentToDocFromMarkdown')) {
+            return Promise.reject(new Error('Network error while importing markdown'));
+          }
+          return Promise.resolve({});
+        });
+
+        const args: inputType = {
+          location: 'workspace',
+          workspace_id: 12345,
+          doc_name: 'Test Document',
+          markdown: 'Valid content',
+        };
+
+        const result = await callToolByNameRawAsync('create_doc', args);
+
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+          message: 'Document created, but failed to add markdown content',
+          doc_id: 'doc_790',
+          object_id: 'obj_790',
+          doc_url: 'https://monday.com/docs/obj_790',
+          doc_name: 'Test Document',
+          markdown_content_added: false,
+          markdown_content_error: 'Network error while importing markdown',
+        });
       });
 
       it('should handle GraphQL request exception', async () => {
@@ -829,9 +875,15 @@ describe('CreateDocTool', () => {
 
         const result = await callToolByNameRawAsync('create_doc', args);
 
-        expect(result.content[0].text).toContain('Document doc_item_333 created');
-        expect(result.content[0].text).toContain('failed to add markdown content');
-        expect(result.content[0].text).toContain('Markdown parsing error');
+        expect(JSON.parse(result.content[0].text)).toMatchObject({
+          message: 'Document created, but failed to add markdown content',
+          doc_id: 'doc_item_333',
+          object_id: 'obj_item_333',
+          doc_url: 'https://monday.com/docs/obj_item_333',
+          doc_name: 'Test Document',
+          markdown_content_added: false,
+          markdown_content_error: 'Markdown parsing error',
+        });
       });
     });
   });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.ts
@@ -204,7 +204,7 @@ USAGE EXAMPLES:
               docId: docId,
               name: input.doc_name,
             };
-            const updateRes: UpdateDocNameMutation = await this.mondayApi.request(updateDocName, updateVariables);
+            await this.mondayApi.request(updateDocName, updateVariables);
           } catch (updateError) {
             // Non-fatal error - doc was created but naming failed
             console.warn('Failed to update doc name:', updateError);
@@ -216,22 +216,38 @@ USAGE EXAMPLES:
         return { content: 'Error: Failed to create document.' };
       }
 
-      // Add markdown content to the doc
-      const contentVariables: AddContentToDocFromMarkdownMutationVariables = {
-        docId,
-        markdown: input.markdown,
-      };
-      const contentRes: AddContentToDocFromMarkdownMutation = await this.mondayApi.request(
-        addContentToDocFromMarkdown,
-        contentVariables,
-      );
+      const createPartialSuccessContent = (markdownContentError: string) => ({
+        message: 'Document created, but failed to add markdown content',
+        doc_id: docId,
+        object_id: docObjectId,
+        doc_url: docUrl,
+        doc_name: input.doc_name,
+        markdown_content_added: false,
+        markdown_content_error: markdownContentError,
+      });
 
-      const success = contentRes?.add_content_to_doc_from_markdown?.success;
-      const errorMsg = contentRes?.add_content_to_doc_from_markdown?.error;
+      try {
+        // Add markdown content to the doc
+        const contentVariables: AddContentToDocFromMarkdownMutationVariables = {
+          docId,
+          markdown: input.markdown,
+        };
+        const contentRes: AddContentToDocFromMarkdownMutation = await this.mondayApi.request(
+          addContentToDocFromMarkdown,
+          contentVariables,
+        );
 
-      if (!success) {
+        const success = contentRes?.add_content_to_doc_from_markdown?.success;
+        const errorMsg = contentRes?.add_content_to_doc_from_markdown?.error;
+
+        if (!success) {
+          return {
+            content: createPartialSuccessContent(errorMsg || 'Unknown error'),
+          };
+        }
+      } catch (error) {
         return {
-          content: `Document ${docId} created, but failed to add markdown content: ${errorMsg || 'Unknown error'}`,
+          content: createPartialSuccessContent(error instanceof Error ? error.message : 'Unknown error'),
         };
       }
 


### PR DESCRIPTION
## Summary
- return a structured partial-success payload when `create_doc` succeeds but `addContentToDocFromMarkdown` fails afterward
- preserve the existing hard-failure behavior for true create failures and keep full success responses unchanged
- add focused regressions for workspace/item markdown failures and a thrown append-mutation failure after document creation

## Validation
- `cd packages/agent-toolkit && npx jest src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.test.ts --runInBand`
- `cd packages/agent-toolkit && npx eslint src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.ts src/core/tools/platform-api-tools/create-doc-tool/create-doc-tool.test.ts --max-warnings=0`
- `cd packages/agent-toolkit && yarn build`