### PR TITLE
fix(create-update): reject unsupported mentions

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool-ui/create-update-ui-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool-ui/create-update-ui-tool.ts
@@ -21,12 +21,12 @@ export const createUpdateToolSchema = {
   itemId: z.number().describe('The id of the item to which the update will be added'),
   body: z
     .string()
-    .describe('The update text to be created. Do not use @ to mention users, use the mentionsList field instead.'),
+    .describe('The update text to be created.'),
   mentionsList: z
     .string()
     .optional()
     .describe(
-      'Optional JSON array of mentions in the format: [{"id": "123", "type": "User"}, {"id": "456", "type": "Team"}]. Valid types are: User, Team, Board, Project',
+      'Optional JSON array of mentions. This field is currently unsupported by monday.com create_update and will return a validation error when provided.',
     ),
 };
 
@@ -41,7 +41,7 @@ export class CreateUpdateInMondayTool extends BaseMondayApiTool<typeof createUpd
   });
 
   getDescription(): string {
-    return 'Create a new update (comment/post) on a monday.com item. Updates can be used to add comments, notes, or discussions to items. You can optionally mention users, teams, or boards in the update. After calling this tool you should call the full board data tool to get data, and immediately after that call the show table tool to show the data from that tool. IMPORTANT: You MUST use the COMPLETE data from the full board data tool - do NOT cut, truncate, or omit any data. Pass the entire dataset to the show table tool.';
+    return 'Create a new update (comment/post) on a monday.com item. Updates can be used to add comments, notes, or discussions to items. After calling this tool you should call the full board data tool to get data, and immediately after that call the show table tool to show the data from that tool. IMPORTANT: You MUST use the COMPLETE data from the full board data tool - do NOT cut, truncate, or omit any data. Pass the entire dataset to the show table tool. Note: mentionsList is currently unsupported by the monday.com create_update API.';
   }
 
   getInputSchema(): typeof createUpdateToolSchema {
@@ -64,13 +64,16 @@ export class CreateUpdateInMondayTool extends BaseMondayApiTool<typeof createUpd
       } catch (error) {
         throw new Error(`Invalid mentionsList JSON format: ${(error as Error).message}`);
       }
+
+      if (parsedMentionsList.length > 0) {
+        throw new Error('mentionsList is currently unsupported by the monday.com create_update API');
+      }
     }
 
     try {
       const variables: CreateUpdateMutationVariables = {
         itemId: input.itemId.toString(),
         body: input.body,
-        mentionsList: parsedMentionsList,
       };
 
       const res = await this.mondayApi.request<CreateUpdateMutation>(createUpdate, variables);

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool/create-update-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool/create-update-tool.test.ts
@@ -26,31 +26,22 @@ describe('Create Update Tool', () => {
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createUpdate'), {
       itemId: '456',
       body: 'This is a test update',
-      mentionsList: undefined,
       parentId: undefined,
     });
   });
 
-  it('Successfully creates an update with mentions', async () => {
-    mocks.setResponse(successfulResponse);
+  it('Throws error when mentionsList is provided', async () => {
     const tool = new CreateUpdateTool(mocks.mockApiClient, 'fake_token');
 
-    const result = await tool.execute({
-      itemId: 789,
-      body: 'Hey, check this out!',
-      mentionsList: '[{"id": "12345", "type": "User"}, {"id": "456", "type": "Team"}]',
-    });
+    await expect(
+      tool.execute({
+        itemId: 789,
+        body: 'Hey, check this out!',
+        mentionsList: '[{"id": "12345", "type": "User"}, {"id": "456", "type": "Team"}]',
+      }),
+    ).rejects.toThrow('mentionsList is currently unsupported by the monday.com create_update API');
 
-    expect(result.content).toEqual({ message: 'Update 123456789 created on item 789', update_id: '123456789', item_id: 789, item_name: undefined, item_url: undefined });
-    expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createUpdate'), {
-      itemId: '789',
-      body: 'Hey, check this out!',
-      mentionsList: [
-        { id: '12345', type: 'User' },
-        { id: '456', type: 'Team' },
-      ],
-      parentId: undefined,
-    });
+    expect(mocks.getMockRequest()).not.toHaveBeenCalled();
   });
 
   it('Successfully creates a reply to an existing update using parentId', async () => {
@@ -67,7 +58,6 @@ describe('Create Update Tool', () => {
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createUpdate'), {
       itemId: '456',
       body: 'This is a reply',
-      mentionsList: undefined,
       parentId: '111222',
     });
   });
@@ -156,29 +146,19 @@ describe('Create Update Tool', () => {
     ).rejects.toThrow(/Invalid mentionsList format/);
   });
 
-  it('Successfully validates all valid mention types', async () => {
-    mocks.setResponse(successfulResponse);
+  it('Rejects valid mention payloads because monday create_update does not support mentionsList', async () => {
     const tool = new CreateUpdateTool(mocks.mockApiClient, 'fake_token');
 
-    const result = await tool.execute({
-      itemId: 789,
-      body: 'Test with all types',
-      mentionsList:
-        '[{"id": "1", "type": "User"}, {"id": "2", "type": "Team"}, {"id": "3", "type": "Board"}, {"id": "4", "type": "Project"}]',
-    });
+    await expect(
+      tool.execute({
+        itemId: 789,
+        body: 'Test with all types',
+        mentionsList:
+          '[{"id": "1", "type": "User"}, {"id": "2", "type": "Team"}, {"id": "3", "type": "Board"}, {"id": "4", "type": "Project"}]',
+      }),
+    ).rejects.toThrow('mentionsList is currently unsupported by the monday.com create_update API');
 
-    expect(result.content).toEqual({ message: 'Update 123456789 created on item 789', update_id: '123456789', item_id: 789, item_name: undefined, item_url: undefined });
-    expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createUpdate'), {
-      itemId: '789',
-      body: 'Test with all types',
-      mentionsList: [
-        { id: '1', type: 'User' },
-        { id: '2', type: 'Team' },
-        { id: '3', type: 'Board' },
-        { id: '4', type: 'Project' },
-      ],
-      parentId: undefined,
-    });
+    expect(mocks.getMockRequest()).not.toHaveBeenCalled();
   });
 
   it('Handles GraphQL response errors', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool/create-update-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool/create-update-tool.ts
@@ -22,13 +22,13 @@ export const createUpdateToolSchema = {
   body: z
     .string()
     .describe(
-      'The update text to be created. Do not use @ to mention users, use the mentionsList field instead. use html tags to format the text, dont use markdown.',
+      'The update text to be created. Use html tags to format the text, dont use markdown.',
     ),
   mentionsList: z
     .string()
     .optional()
     .describe(
-      'Optional JSON array of mentions in the format: [{"id": "123", "type": "User"}, {"id": "456", "type": "Team"}]. Valid types are: User, Team, Board, Project',
+      'Optional JSON array of mentions. This field is currently unsupported by monday.com create_update and will return a validation error when provided.',
     ),
   parentId: z
     .number()
@@ -47,7 +47,7 @@ export class CreateUpdateTool extends BaseMondayApiTool<typeof createUpdateToolS
   });
 
   getDescription(): string {
-    return 'Create a new update (comment/post) on a monday.com item. Updates can be used to add comments, notes, or discussions to items. You can optionally mention users, teams, or boards in the update. You can also reply to an existing update by using the parentId parameter.';
+    return 'Create a new update (comment/post) on a monday.com item. Updates can be used to add comments, notes, or discussions to items. You can also reply to an existing update by using the parentId parameter. Note: mentionsList is currently unsupported by the monday.com create_update API.';
   }
 
   getInputSchema(): typeof createUpdateToolSchema {
@@ -70,13 +70,16 @@ export class CreateUpdateTool extends BaseMondayApiTool<typeof createUpdateToolS
       } catch (error) {
         throw new Error(`Invalid mentionsList JSON format: ${(error as Error).message}`);
       }
+
+      if (parsedMentionsList.length > 0) {
+        throw new Error('mentionsList is currently unsupported by the monday.com create_update API');
+      }
     }
 
     try {
       const variables: CreateUpdateMutationVariables = {
         itemId: input.itemId.toString(),
         body: input.body,
-        mentionsList: parsedMentionsList,
         parentId: input.parentId?.toString(),
       };
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool/create-update.graphql.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-update-tool/create-update.graphql.ts
@@ -1,8 +1,8 @@
 import { gql } from 'graphql-request';
 
 export const createUpdate = gql`
-  mutation createUpdate($itemId: ID!, $body: String!, $mentionsList: [UpdateMention], $parentId: ID) {
-    create_update(body: $body, item_id: $itemId, mentions_list: $mentionsList, parent_id: $parentId) {
+  mutation createUpdate($itemId: ID!, $body: String!, $parentId: ID) {
+    create_update(body: $body, item_id: $itemId, parent_id: $parentId) {
       id
       item_id
       item {


### PR DESCRIPTION
## Summary
- remove the unsupported `UpdateMention` / `mentions_list` fields from the shared `create_update` mutation so plain update creation no longer fails against monday's current schema
- fail fast with a clear tool-level error when `mentionsList` is provided instead of sending an API request that the schema cannot satisfy
- keep normal update creation and `parentId` replies working, and cover the compatibility change with focused create-update tests

## Validation
- `cd packages/agent-toolkit && npx jest src/core/tools/platform-api-tools/create-update-tool/create-update-tool.test.ts --runInBand`
- `cd packages/agent-toolkit && npx eslint src/core/tools/platform-api-tools/create-update-tool/create-update.graphql.ts src/core/tools/platform-api-tools/create-update-tool/create-update-tool.ts src/core/tools/platform-api-tools/create-update-tool/create-update-tool.test.ts src/core/tools/platform-api-tools/create-update-tool-ui/create-update-ui-tool.ts --max-warnings=0`
- `cd packages/agent-toolkit && yarn build`