### PR TITLE
fix(agent-toolkit): add graphql-tag runtime dependency

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -50,6 +50,7 @@
   "dependencies": {
     "@mondaydotcomorg/api": "^13.0.0",
     "axios": "^1.10.0",
+    "graphql-tag": "^2.12.6",
     "jsonwebtoken": "^9.0.2",
     "zod": "^3.24.2",
     "zod-to-json-schema": "^3.24.5"


### PR DESCRIPTION
## Summary
- add `graphql-tag` as an explicit runtime dependency of `@mondaydotcomorg/agent-toolkit`
- keep the fix scoped to package metadata so published installs no longer rely on transitive dependency luck when `@mondaydotcomorg/api` requires `graphql-tag`

## Validation
- `yarn install`
- `cd packages/agent-toolkit && yarn build`
- `cd packages/monday-api-mcp && yarn build`
- `cd packages/agent-toolkit && npm pack --json` (packed manifest now includes `graphql-tag` under `dependencies`)