### PR TITLE
fix(create-form): set workforms API version override

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/create-form-tool/create-form-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/create-form-tool/create-form-tool.test.ts
@@ -1,0 +1,59 @@
+import { z, ZodTypeAny } from 'zod';
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameRawAsync, createMockApiClient } from '../../test-utils/mock-api-client';
+import { createFormToolSchema } from './schema';
+
+type inputType = z.objectInputType<typeof createFormToolSchema, ZodTypeAny>;
+
+describe('CreateFormTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('uses the 2025-10 API version override when creating a form', async () => {
+    mocks.setResponse({
+      create_form: {
+        boardId: 'board_123',
+        token: 'form_token_123',
+      },
+    });
+
+    const args: inputType = {
+      destination_workspace_id: '12345',
+      destination_name: 'Test Form',
+    };
+
+    const result = await callToolByNameRawAsync('create_form', args);
+
+    expect(JSON.parse(result.content[0].text)).toEqual({
+      message: 'Form created successfully',
+      board_id: 'board_123',
+      form_token: 'form_token_123',
+    });
+
+    expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
+
+    const mockCall = mocks.getMockRequest().mock.calls[0];
+    expect(mockCall[0]).toContain('mutation createForm');
+    expect(mockCall[1]).toEqual({
+      destination_workspace_id: '12345',
+      destination_folder_id: undefined,
+      destination_folder_name: undefined,
+      board_kind: undefined,
+      destination_name: 'Test Form',
+      board_owner_ids: undefined,
+      board_owner_team_ids: undefined,
+      board_subscriber_ids: undefined,
+      board_subscriber_teams_ids: undefined,
+    });
+    expect(mockCall[2]).toEqual(expect.objectContaining({ versionOverride: '2025-10' }));
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/create-form-tool/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/create-form-tool/index.ts
@@ -38,7 +38,7 @@ export class CreateFormTool extends BaseMondayApiTool<typeof createFormToolSchem
       board_subscriber_teams_ids: input.board_subscriber_teams_ids,
     };
 
-    const res = await this.mondayApi.request<CreateFormMutation>(createForm, variables);
+    const res = await this.mondayApi.request<CreateFormMutation>(createForm, variables, { versionOverride: '2025-10' });
 
     return {
       content: { message: "Form created successfully", board_id: res.create_form?.boardId, form_token: res.create_form?.token },


### PR DESCRIPTION
## Summary
- send `versionOverride: '2025-10'` when calling the `create_form` workforms mutation
- add a focused tool-level regression that locks the override into the monday API request contract
- keep the fix scoped to the create-form tool without broadening other workforms tools

## Validation
- `cd packages/agent-toolkit && npx jest src/core/tools/platform-api-tools/workforms-tools/create-form-tool/create-form-tool.test.ts --runInBand`
- `cd packages/agent-toolkit && npx eslint src/core/tools/platform-api-tools/workforms-tools/create-form-tool/index.ts src/core/tools/platform-api-tools/workforms-tools/create-form-tool/create-form-tool.test.ts --max-warnings=0`
- `cd packages/agent-toolkit && yarn build`