### PR TITLE
fix(agent-toolkit): sanitize unsafe tool descriptions

### DIFF
--- a/packages/agent-toolkit/src/mcp/toolkit.test.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.test.ts
@@ -495,6 +495,33 @@ describe('MondayAgentToolkit', () => {
       expect(typeof tools[1].handler).toBe('function');
     });
 
+    it('should sanitize unsafe characters in tool descriptions', () => {
+      const mockTool = {
+        name: 'unsafe-description-tool',
+        type: ToolType.READ,
+        annotations: { audience: [] },
+        enabledByDefault: true,
+        getDescription: jest
+          .fn()
+          .mockReturnValue('Use `position`; then call `refresh`.'),
+        getInputSchema: jest.fn().mockReturnValue({}),
+        execute: jest.fn().mockResolvedValue({ content: 'OK' }),
+      };
+
+      mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+      const toolkit = new MondayAgentToolkit({
+        mondayApiToken: 'test-token',
+      });
+
+      const tools = toolkit.getTools();
+
+      expect(tools[0]).toHaveProperty(
+        'description',
+        "Use 'position', then call 'refresh'.",
+      );
+    });
+
     it('should include management tool when enabled', () => {
       const mockTool = {
         name: 'regular-tool',
@@ -1006,6 +1033,33 @@ describe('MondayAgentToolkit', () => {
       expect(result).toEqual({
         content: [{ type: 'text', text: 'Test content' }],
       });
+    });
+
+    it('should sanitize unsafe characters in MCP tool descriptions', () => {
+      const mockTool = {
+        name: 'mcp-unsafe-description-tool',
+        type: ToolType.READ,
+        annotations: { audience: [] },
+        enabledByDefault: true,
+        getDescription: jest
+          .fn()
+          .mockReturnValue('Use `position`; then call `refresh`.'),
+        getInputSchema: jest.fn().mockReturnValue({}),
+        execute: jest.fn().mockResolvedValue({ content: 'MCP result' }),
+      };
+
+      mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+      const toolkit = new MondayAgentToolkit({
+        mondayApiToken: 'test-token',
+      });
+
+      const tools = toolkit.getToolsForMcp();
+
+      expect(tools[0]).toHaveProperty(
+        'description',
+        "Use 'position', then call 'refresh'.",
+      );
     });
 
     it('should handle errors in MCP format', async () => {

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -193,6 +193,10 @@ export class MondayAgentToolkit extends McpServer {
     return this;
   }
 
+  private sanitizeToolDescription(description: string): string {
+    return description.replaceAll(';', ',').replaceAll('`', "'");
+  }
+
   /**
    * Get all tools as an array of tool objects that can be registered individually
    * Each tool includes name, description, schema, annotations, and handler for external registration
@@ -215,7 +219,7 @@ export class MondayAgentToolkit extends McpServer {
 
     return allTools.map((tool) => ({
       name: tool.name,
-      description: tool.getDescription(),
+      description: this.sanitizeToolDescription(tool.getDescription()),
       schema: this.getSchemaForTool(tool, options),
       annotations: tool.annotations,
       handler: this.createToolHandler(tool),
@@ -244,7 +248,7 @@ export class MondayAgentToolkit extends McpServer {
 
     return allTools.map((tool) => ({
       name: tool.name,
-      description: tool.getDescription(),
+      description: this.sanitizeToolDescription(tool.getDescription()),
       schema: this.getSchemaForTool(tool, options),
       annotations: tool.annotations,
       handler: this.createMcpToolHandler(tool),

--- a/packages/agent-toolkit/src/openai/toolkit.test.ts
+++ b/packages/agent-toolkit/src/openai/toolkit.test.ts
@@ -1,0 +1,60 @@
+import { ApiClient } from '@mondaydotcomorg/api';
+import { MondayAgentToolkit } from './toolkit';
+import { ToolType } from '../core/tool';
+import { getFilteredToolInstances } from '../utils/tools/tools-filtering.utils';
+import { API_VERSION } from 'src/utils';
+
+jest.mock('@mondaydotcomorg/api', () => ({
+  ApiClient: jest.fn().mockImplementation(() => ({})),
+}));
+
+jest.mock('../utils/tools/tools-filtering.utils', () => ({
+  getFilteredToolInstances: jest.fn(),
+}));
+
+const mockGetFilteredToolInstances = getFilteredToolInstances as jest.MockedFunction<
+  typeof getFilteredToolInstances
+>;
+const mockApiClient = ApiClient as jest.MockedClass<typeof ApiClient>;
+
+describe('OpenAI MondayAgentToolkit', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFilteredToolInstances.mockReturnValue([]);
+  });
+
+  it('should initialize the monday API client with default API version', () => {
+    new MondayAgentToolkit({
+      mondayApiToken: 'test-token',
+    });
+
+    expect(mockApiClient).toHaveBeenCalledWith({
+      token: 'test-token',
+      apiVersion: API_VERSION,
+      endpoint: undefined,
+      requestConfig: undefined,
+    });
+  });
+
+  it('should sanitize unsafe characters in OpenAI tool descriptions', () => {
+    const mockTool = {
+      name: 'unsafe-description-tool',
+      type: ToolType.READ,
+      annotations: { audience: [] },
+      enabledByDefault: true,
+      getDescription: jest.fn().mockReturnValue('Use `position`; then call `refresh`.'),
+      getInputSchema: jest.fn().mockReturnValue({}),
+      execute: jest.fn().mockResolvedValue({ content: 'OK' }),
+    };
+
+    mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+    const toolkit = new MondayAgentToolkit({
+      mondayApiToken: 'test-token',
+    });
+
+    const tools = toolkit.getTools();
+
+    expect(tools[0]?.function.description).toBe("Use 'position', then call 'refresh'.");
+  });
+});

--- a/packages/agent-toolkit/src/openai/toolkit.ts
+++ b/packages/agent-toolkit/src/openai/toolkit.ts
@@ -50,6 +50,10 @@ export class MondayAgentToolkit {
     return filteredToolInstances;
   }
 
+  private sanitizeToolDescription(description: string): string {
+    return description.replaceAll(';', ',').replaceAll('`', "'");
+  }
+
   /**
    * Returns the tools that are available to be used in the OpenAI API.
    *
@@ -62,7 +66,7 @@ export class MondayAgentToolkit {
         type: 'function',
         function: {
           name: tool.name,
-          description: tool.getDescription(),
+          description: this.sanitizeToolDescription(tool.getDescription()),
           parameters: inputSchema ? zodToJsonSchema(z.object(inputSchema)) : undefined,
         },
       };


### PR DESCRIPTION
## Summary
- sanitize unsafe characters in exported MCP tool descriptions so downstream clients that reject backticks and semicolons can still import the monday catalog
- keep the fix scoped to the MCP toolkit export layer instead of rewriting individual tool descriptions at the source
- add focused toolkit regressions covering sanitized descriptions for both `getTools()` and `getToolsForMcp()`

## Validation
- `cd packages/agent-toolkit && npx jest src/mcp/toolkit.test.ts --runInBand`
- `cd packages/agent-toolkit && npx eslint src/mcp/toolkit.ts src/mcp/toolkit.test.ts --max-warnings=0`
- `cd packages/agent-toolkit && yarn build`