### PR TITLE
fix(monday-dev): use dev API version for sprints metadata

### DIFF
--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.test.ts
@@ -13,7 +13,7 @@ import {
   MALFORMED_BOARD_RESPONSE,
 } from './get-sprints-metadata-tool-test-data';
 
-export type InputType = Partial<z.infer<z.ZodObject<typeof getSprintsMetadataToolSchema>>> & { sprintsBoardId: number };
+type InputType = Partial<z.infer<z.ZodObject<typeof getSprintsMetadataToolSchema>>> & { sprintsBoardId: number };
 
 describe('GetSprintsMetadataTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
@@ -62,9 +62,11 @@ describe('GetSprintsMetadataTool', () => {
 
       expect(schemaCall).toBeDefined();
       expect(schemaCall[1]).toEqual({ boardId: '123456789' });
+      expect(schemaCall[2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
 
       expect(itemsCall).toBeDefined();
       expect(itemsCall[1]).toEqual({ boardId: '123456789', limit: 25 });
+      expect(itemsCall[2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
     });
 
     it('should successfully get sprints metadata with custom limit', async () => {
@@ -85,6 +87,7 @@ describe('GetSprintsMetadataTool', () => {
 
       expect(itemsCall).toBeDefined();
       expect(itemsCall[1]).toEqual({ boardId: '123456789', limit: 50 });
+      expect(itemsCall[2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
     });
   });
 

--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.ts
@@ -95,6 +95,7 @@ Requires the Main Sprints board ID of the monday-dev containing your sprints.`;
       const res = await this.mondayApi.request<GetSprintsBoardItemsWithColumnsQuery>(
         getSprintsBoardItemsWithColumns,
         variables,
+        { versionOverride: 'dev' },
       );
 
       const board = res.boards?.[0];
@@ -127,7 +128,7 @@ Requires the Main Sprints board ID of the monday-dev containing your sprints.`;
         boardId: boardId.toString(),
       };
 
-      const res = await this.mondayApi.request<GetBoardSchemaQuery>(getBoardSchema, variables);
+      const res = await this.mondayApi.request<GetBoardSchemaQuery>(getBoardSchema, variables, { versionOverride: 'dev' });
 
       const board = res.boards?.[0];
       if (!board) {


### PR DESCRIPTION
## Summary
- send `versionOverride: 'dev'` when validating and fetching Monday Dev sprints board metadata
- keep the fix scoped to the `get_sprints_metadata` tool without broadening other Monday Dev queries
- add focused assertions that both the schema validation query and the sprints metadata query use the dev API version override

## Validation
- `cd packages/agent-toolkit && npx jest src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.test.ts --runInBand`
- `cd packages/agent-toolkit && npx eslint src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.ts src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.test.ts --max-warnings=0`
- `cd packages/agent-toolkit && yarn build`