### PR TITLE
fix(monday-dev): use dev API version for sprints boards

### DIFF
--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.test.ts
@@ -49,6 +49,7 @@ describe('GetSprintsBoardsTool', () => {
       expect(calls.length).toBe(1);
       expect(calls[0][0]).toContain('query GetRecentBoards');
       expect(calls[0][1]).toEqual({ limit: 100 });
+      expect(calls[0][2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
     });
 
     it('should successfully find multiple board pairs', async () => {

--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.ts
@@ -58,7 +58,9 @@ Searches recently used boards (up to ${RECENT_BOARDS_LIMIT}). If none found, ask
         limit: RECENT_BOARDS_LIMIT,
       };
 
-      const res = await this.mondayApi.request<GetRecentBoardsQuery>(getRecentBoards, variables);
+      const res = await this.mondayApi.request<GetRecentBoardsQuery>(getRecentBoards, variables, {
+        versionOverride: 'dev',
+      });
 
       const boards = (res.boards || []).filter((board): board is Board => board !== null);
 


### PR DESCRIPTION
## Summary
- send `versionOverride: 'dev'` when fetching Monday Dev sprint board pairs from `get_monday_dev_sprints_boards`
- keep the fix scoped to the board discovery tool without broadening other Monday Dev queries
- add a focused assertion that the recent-boards request uses the dev API override

## Validation
- `cd packages/agent-toolkit && npx jest src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.test.ts --runInBand`
- `cd packages/agent-toolkit && npx eslint src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.ts src/core/tools/monday-dev-tools/get-sprints-boards-tool/get-sprints-boards-tool.test.ts --max-warnings=0`
- `cd packages/agent-toolkit && yarn build`