### PR TITLE
fix(monday-dev): use dev API version for sprint summary

### DIFF
--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.test.ts
@@ -61,14 +61,17 @@ describe('GetSprintSummaryTool', () => {
       const sprintCall = calls.find((call) => call[0].includes('query getSprintsByIds'));
       expect(sprintCall).toBeDefined();
       expect(sprintCall[1]).toEqual({ ids: ['1004'] });
+      expect(sprintCall[2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
 
       const docCall = calls.find((call) => call[0].includes('query readDocs'));
       expect(docCall).toBeDefined();
       expect(docCall[1]).toEqual({ object_ids: ['doc_obj_summary_1004'], limit: 1 });
+      expect(docCall[2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
 
       const exportCall = calls.find((call) => call[0].includes('query exportMarkdownFromDoc'));
       expect(exportCall).toBeDefined();
       expect(exportCall[1]).toEqual({ docId: 'doc_internal_1004', blockIds: [] });
+      expect(exportCall[2]).toEqual(expect.objectContaining({ versionOverride: 'dev' }));
     });
 
     it('should have correct tool metadata', () => {

--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.ts
@@ -111,7 +111,9 @@ When viewing the section "Completed by Assignee", you'll see user IDs in the for
         ids: [String(sprintId)],
       };
 
-      const res = await this.mondayApi.request<GetSprintsByIdsQuery>(getSprintsByIds, variables);
+      const res = await this.mondayApi.request<GetSprintsByIdsQuery>(getSprintsByIds, variables, {
+        versionOverride: 'dev',
+      });
 
       const sprints = res.items || [];
 
@@ -174,7 +176,9 @@ When viewing the section "Completed by Assignee", you'll see user IDs in the for
         limit: DOCS_LIMIT,
       };
 
-      const docsResponse = await this.mondayApi.request<ReadDocsQuery>(readSprintSummaryDocs, readDocsVariables);
+      const docsResponse = await this.mondayApi.request<ReadDocsQuery>(readSprintSummaryDocs, readDocsVariables, {
+        versionOverride: 'dev',
+      });
 
       const docs = docsResponse.docs || [];
       if (docs.length === 0) {
@@ -201,6 +205,7 @@ When viewing the section "Completed by Assignee", you'll see user IDs in the for
       const exportResponse = await this.mondayApi.request<ExportMarkdownFromDocQuery>(
         exportSprintSummaryMarkdown,
         exportVariables,
+        { versionOverride: 'dev' },
       );
 
       if (!exportResponse.export_markdown_from_doc?.success) {


### PR DESCRIPTION
## Summary
- route sprint summary metadata lookup through the dev API version
- route sprint summary doc reads and markdown export through the dev API version too
- add regression coverage to assert all three GraphQL requests pass `versionOverride: 'dev'`

## Testing
- `npx jest src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.test.ts`
- `npx eslint src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.ts src/core/tools/monday-dev-tools/get-sprint-summary-tool/get-sprint-summary-tool.test.ts`
- `npm run build`