### PR TITLE
fix(get_updates): treat date-only toDate as end of day

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts
@@ -389,7 +389,7 @@ describe('Get Updates Tool', () => {
     await expect(tool.execute({ itemId: 123, page: 0 } as any)).rejects.toThrow();
   });
 
-  it('Successfully gets board updates with date range filtering', async () => {
+  it('Successfully gets board updates with date-only range filtering', async () => {
     mocks.setResponse(mockBoardUpdatesResponse);
     const tool = new GetUpdatesTool(mocks.mockApiClient);
 
@@ -410,7 +410,7 @@ describe('Get Updates Tool', () => {
         limit: 25,
         page: 1,
         fromDate: '2024-01-01T00:00:00Z',
-        toDate: '2024-01-31T00:00:00Z',
+        toDate: '2024-01-31T23:59:59Z',
         boardUpdatesOnly: true,
       }),
     );

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts
@@ -50,9 +50,9 @@ export const getUpdatesToolSchema = {
     ),
 };
 
-function normalizeToISO8601DateTime(date: string): string {
+function normalizeToISO8601DateTime(date: string, boundary: 'start' | 'end' = 'start'): string {
   if (/^\d{4}-\d{2}-\d{2}$/.test(date)) {
-    return `${date}T00:00:00Z`;
+    return boundary === 'end' ? `${date}T23:59:59Z` : `${date}T00:00:00Z`;
   }
   return date;
 }
@@ -110,7 +110,12 @@ export class GetUpdatesTool extends BaseMondayApiTool<typeof getUpdatesToolSchem
           ...variables,
           boardId: input.objectId,
           boardUpdatesOnly: !(input.includeItemUpdates ?? false),
-          ...(input.fromDate && input.toDate ? { fromDate: normalizeToISO8601DateTime(input.fromDate), toDate: normalizeToISO8601DateTime(input.toDate) } : {}),
+          ...(input.fromDate && input.toDate
+            ? {
+                fromDate: normalizeToISO8601DateTime(input.fromDate, 'start'),
+                toDate: normalizeToISO8601DateTime(input.toDate, 'end'),
+              }
+            : {}),
         });
       }
 


### PR DESCRIPTION
## Summary
- normalize date-only `toDate` values in `get_updates` to the end of the requested day
- keep date-only `fromDate` normalization at the start of the day
- update the co-located Jest coverage to lock the inclusive end-date behavior

## Testing
- `npx jest src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts -t "date range"`
- `npx jest src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts`
- `npm run build`