### PR TITLE
fix(list_workspaces): suppress false next_page hints

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts
@@ -3,7 +3,7 @@ import { callToolByNameRawAsync, createMockApiClient } from '../test-utils/mock-
 import { listWorkspaceToolSchema } from './list-workspace-tool';
 import { z, ZodTypeAny } from 'zod';
 
-export type inputType = z.objectInputType<typeof listWorkspaceToolSchema, ZodTypeAny>;
+type inputType = z.objectInputType<typeof listWorkspaceToolSchema, ZodTypeAny>;
 
 const addDummyWorkspaces = (
   workspaces: { id: string; name: string; description: string }[],
@@ -170,6 +170,7 @@ describe('ListWorkspaceTool', () => {
 
       const args: inputType = {
         searchTerm: 'Marketing',
+        limit: 5,
       };
 
       const result = await callToolByNameRawAsync('list_workspaces', args);
@@ -277,6 +278,7 @@ describe('ListWorkspaceTool', () => {
       expect(parsed.disclaimer).toBe(
         'Search term not applied - returning all workspaces. Perform the filtering manually.',
       );
+      expect(parsed.next_page).toBeUndefined();
     });
 
     it('should fallback to all workspaces when search term not found in member workspaces', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.ts
@@ -110,8 +110,7 @@ export class ListWorkspaceTool extends BaseMondayApiTool<typeof listWorkspaceToo
       };
     }
 
-    // Naive check to see if there are more pages
-    const hasMorePages = filteredWorkspaces.length === input.limit;
+    const hasMorePages = !shouldIncludeNoFilteringDisclaimer && filteredWorkspaces.length === input.limit;
 
     const slug = await fetchAccountSlug(this.mondayApi);
     const workspacesWithUrls = filteredWorkspaces.map(ws => ({


### PR DESCRIPTION
## Summary
- stop emitting `next_page` when `list_workspaces` returns an unfiltered disclaimer payload that exactly matches the requested limit
- keep `next_page` for the real in-memory filtered pagination path only
- add a regression test covering the disclaimer path with `limit` equal to the returned workspace count

## Testing
- `npx jest src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.ts src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts`
- `npm run build`