### PR TITLE
fix(workspace_info): guard null workspace results

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.test.ts
@@ -1,7 +1,41 @@
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameRawAsync, createMockApiClient } from '../test-utils/mock-api-client';
 import { organizeWorkspaceInfoHierarchy } from './helpers';
 import { WorkspaceKind, State } from '../../../../monday-graphql/generated/graphql/graphql';
 
 describe('WorkspaceInfoTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('executeInternal', () => {
+    it('should return a no-workspace message when the API returns only null workspaces', async () => {
+      mocks.setResponses([
+        {
+          workspaces: [null],
+          boards: [],
+          docs: [],
+          folders: [],
+        },
+      ]);
+
+      const result = await callToolByNameRawAsync('workspace_info', {
+        workspace_id: 123,
+      });
+
+      expect(result.content[0].text).toBe('No workspace found with ID 123');
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
+    });
+  });
+
   describe('organizeWorkspaceInfoHierarchy', () => {
     it('should organize workspace data with proper hierarchy', () => {
       const rawResponse = {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.ts
@@ -37,7 +37,7 @@ export class WorkspaceInfoTool extends BaseMondayApiTool<typeof workspaceInfoToo
 
     const res = await this.mondayApi.request<GetWorkspaceInfoQuery>(getWorkspaceInfo, variables);
 
-    if (!res.workspaces || res.workspaces.length === 0) {
+    if (!res.workspaces?.some((workspace) => workspace != null)) {
       return {
         content: `No workspace found with ID ${input.workspace_id}`,
       };


### PR DESCRIPTION
## Summary
- treat `[null]` workspace responses as a friendly not-found result instead of letting the helper throw a generic error
- keep the hierarchy helper unchanged and stop before it is called with an empty workspace selection
- add regression coverage for the nullable workspace response path

## Testing
- `npx jest src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.ts src/core/tools/platform-api-tools/workspace-info-tool/workspace-info-tool.test.ts`
- `npm run build`