### PR TITLE
fix(list_users_and_teams): ignore null users in name results

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts
@@ -1,3 +1,5 @@
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameRawAsync, createMockApiClient } from '../test-utils/mock-api-client';
 import { formatUsersAndTeams } from './list-users-and-teams.utils';
 import { FormattedResponse } from './types';
 
@@ -612,5 +614,44 @@ describe('ListUsersAndTeamsTool - Helper Functions', () => {
       expect(result).toContain('Timezone: America/New_York');
       expect(result).toContain('UTC Hours Diff: -5');
     });
+  });
+});
+
+describe('ListUsersAndTeamsTool - executeInternal', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should count only non-null users in name search results', async () => {
+    mocks.setResponses([
+      {
+        users: [
+          null,
+          {
+            id: '1',
+            name: 'Luke Skywalker',
+            title: 'Jedi Knight',
+          },
+        ],
+      },
+      { me: { account: { slug: 'test-account' } } },
+    ]);
+
+    const result = await callToolByNameRawAsync('list_users_and_teams', {
+      name: 'Luke',
+    });
+
+    const parsed = JSON.parse(result.content[0].text);
+    expect(parsed.data).toContain('Found 1 user(s) matching "Luke":');
+    expect(parsed.data).toContain('Luke Skywalker');
+    expect(parsed.url).toBe('https://test-account.monday.com/teams/all');
   });
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.ts
@@ -171,19 +171,21 @@ export class ListUsersAndTeamsTool extends BaseMondayApiTool<typeof listUsersAnd
 
       const res = await this.mondayApi.request<GetUserByNameQuery>(getUserByName, variables);
 
-      if (!res.users || res.users.length === 0) {
+      const users =
+        res.users?.filter((user): user is NonNullable<typeof user> => user !== null) || [];
+
+      if (users.length === 0) {
         return {
           content: `NAME_SEARCH_EMPTY: No users found matching "${input.name}". Try broader search terms or verify user exists in account.`,
         };
       }
 
       // Convert basic user search response to simplified format
-      const userList = res.users
-        .filter((user) => user !== null)
-        .map((user) => `• **${user!.name}** (ID: ${user!.id})${user!.title ? ` - ${user!.title}` : ''}`)
+      const userList = users
+        .map((user) => `• **${user.name}** (ID: ${user.id})${user.title ? ` - ${user.title}` : ''}`)
         .join('\n');
 
-      const contentStr = `Found ${res.users.length} user(s) matching "${input.name}":\n\n${userList}`;
+      const contentStr = `Found ${users.length} user(s) matching "${input.name}":\n\n${userList}`;
       const slug = await fetchAccountSlug(this.mondayApi);
       return {
         content: {


### PR DESCRIPTION
## Summary
- count only non-null users in name-search results for `list_users_and_teams`
- treat all-null name-search responses as empty rather than returning an inflated count with an empty list
- add regression coverage for the execute path with a nullable user response

## Testing
- `npx jest src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.ts src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts`
- `npm run build`