### PR TITLE
fix(read_docs): ignore null doc entries

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts
@@ -28,6 +28,7 @@ const mockMarkdownResponse = {
 
 const mockDocsResponse = { docs: [mockDoc] };
 const mockEmptyDocsResponse = { docs: [] };
+const mockNullDocsResponse = { docs: [null] };
 
 const mockRestoringPoints = [
   { date: '2026-03-18T10:00:00Z', user_ids: ['1001', '1002'], type: null },
@@ -107,8 +108,28 @@ describe('ReadDocsTool', () => {
       expect(mocks.getMockRequest()).toHaveBeenCalledTimes(3);
     });
 
+    it('should fall back to object_ids when ids returns only null docs', async () => {
+      mocks.mockRequest
+        .mockResolvedValueOnce(mockNullDocsResponse)
+        .mockResolvedValueOnce(mockDocsResponse)
+        .mockResolvedValueOnce(mockMarkdownResponse);
+
+      const result = await callToolByNameAsync(TOOL_NAME, { type: 'ids', ids: [DOC_ID] });
+
+      expect(result.data).toHaveLength(1);
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(3);
+    });
+
     it('should return no documents message when nothing found', async () => {
       mocks.mockRequest.mockResolvedValueOnce(mockEmptyDocsResponse).mockResolvedValueOnce(mockEmptyDocsResponse);
+
+      const result = await callToolByNameRawAsync(TOOL_NAME, { type: 'ids', ids: ['nonexistent'] });
+
+      expect(result.content[0].text).toContain('No documents found');
+    });
+
+    it('should return no documents message when docs only contain null entries', async () => {
+      mocks.mockRequest.mockResolvedValueOnce(mockNullDocsResponse).mockResolvedValueOnce(mockNullDocsResponse);
 
       const result = await callToolByNameRawAsync(TOOL_NAME, { type: 'ids', ids: ['nonexistent'] });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts
@@ -152,7 +152,7 @@ MODE: "version_history" — Fetch the edit history of a single document.
 
       let res = await this.mondayApi.request<ReadDocsQuery>(readDocs, variables);
 
-      if ((!res.docs || res.docs.length === 0) && ids) {
+      if (!res.docs?.some((doc) => doc != null) && ids) {
         const fallbackVariables: ReadDocsQueryVariables & { includeBlocks: boolean } = {
           ids: undefined,
           object_ids: ids,
@@ -165,7 +165,7 @@ MODE: "version_history" — Fetch the edit history of a single document.
         res = await this.mondayApi.request<ReadDocsQuery>(readDocs, fallbackVariables);
       }
 
-      if (!res.docs || res.docs.length === 0) {
+      if (!res.docs?.some((doc) => doc != null)) {
         const pageInfo = input.page ? ` (page ${input.page})` : '';
         return { content: `No documents found matching the specified criteria${pageInfo}.` };
       }


### PR DESCRIPTION
## Summary
- treat `docs: [null]` the same as an empty read_docs result instead of falling through to an empty success payload
- make the ids→object_ids fallback run when the first response only contains null entries
- add regression coverage for both the fallback path and the final no-docs path with nullable doc results

## Testing
- `npx jest src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts`
- `npm run build`