### PR TITLE
fix(get_notetaker_meetings): ignore null meeting entries

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.test.ts
@@ -223,6 +223,14 @@ describe('GetNotetakerMeetingsTool', () => {
 
       expect(result.content[0].text).toBe('No notetaker meetings found matching the specified criteria.');
     });
+
+    it('should return "No notetaker meetings found" when meetings only contain null entries', async () => {
+      mocks.setResponse({ notetaker: { meetings: { meetings: [null], page_info: { has_next_page: false, cursor: null } } } });
+
+      const result = await callToolByNameRawAsync('get_notetaker_meetings', {});
+
+      expect(result.content[0].text).toBe('No notetaker meetings found matching the specified criteria.');
+    });
   });
 
   describe('Include flags', () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.ts
@@ -2,6 +2,7 @@ import { z } from 'zod';
 import { ToolInputType, ToolOutputType, ToolType } from '../../../tool';
 import { BaseMondayApiTool, createMondayApiAnnotations } from '../base-monday-api-tool';
 import { getNotetakerMeetings } from './get-notetaker-meetings-tool.graphql';
+import { GetNotetakerMeetingsQuery } from '../../../../monday-graphql/generated/graphql/graphql';
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
@@ -101,24 +102,30 @@ export class GetNotetakerMeetingsTool extends BaseMondayApiTool<typeof getNoteta
       includeTranscript: input.include_transcript,
     };
 
-    const res = await this.mondayApi.request<any>(getNotetakerMeetings, variables, {
+    const res = await this.mondayApi.request<GetNotetakerMeetingsQuery>(getNotetakerMeetings, variables, {
       versionOverride: '2026-04',
     });
 
     const meetingsResponse = res.notetaker?.meetings;
 
-    if (!meetingsResponse?.meetings || meetingsResponse.meetings.length === 0) {
+    const meetings = meetingsResponse?.meetings?.filter(
+      (meeting): meeting is NonNullable<typeof meeting> => meeting !== null,
+    );
+
+    if (!meetings || meetings.length === 0) {
       return {
         content: 'No notetaker meetings found matching the specified criteria.',
       };
     }
 
+    const pageInfo = meetingsResponse?.page_info;
+
     const result = {
-      meetings: meetingsResponse.meetings,
+      meetings,
       pagination: {
-        has_next_page: meetingsResponse.page_info?.has_next_page ?? false,
-        cursor: meetingsResponse.page_info?.cursor ?? null,
-        count: meetingsResponse.meetings.length,
+        has_next_page: pageInfo?.has_next_page ?? false,
+        cursor: pageInfo?.cursor ?? null,
+        count: meetings.length,
       },
     };
 


### PR DESCRIPTION
## Summary
- treat all-null meeting arrays the same as an empty notetaker result instead of returning a success payload with null entries
- count only non-null meetings in the returned pagination metadata
- add regression coverage for the nullable meetings path

## Testing
- `npx jest src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.ts src/core/tools/platform-api-tools/get-notetaker-meetings-tool/get-notetaker-meetings-tool.test.ts`
- `npm run build`