### PR TITLE
fix(get_updates): ignore null update entries

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts
@@ -331,6 +331,19 @@ describe('Get Updates Tool', () => {
     expect(result.content).toBe('No updates found for item with id 123');
   });
 
+  it('Returns message when updates only contain null entries', async () => {
+    const nullUpdatesResponse = {
+      items: [{ id: '123', updates: [null] }],
+    };
+
+    mocks.setResponse(nullUpdatesResponse);
+    const tool = new GetUpdatesTool(mocks.mockApiClient, 'fake_token');
+
+    const result = await tool.execute({ objectId: '123', objectType: 'Item' } as any);
+
+    expect(result.content).toBe('No updates found for item with id 123');
+  });
+
 
   it('Handles GraphQL response errors', async () => {
     const graphqlError = new Error('GraphQL Error');

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts
@@ -114,9 +114,12 @@ export class GetUpdatesTool extends BaseMondayApiTool<typeof getUpdatesToolSchem
         });
       }
 
-      const updates = input.objectType === UpdateObjectType.Item ? (res as GetItemUpdatesQuery).items?.[0]?.updates : (res as GetBoardUpdatesQuery).boards?.[0]?.updates;
+      const rawUpdates = input.objectType === UpdateObjectType.Item
+        ? (res as GetItemUpdatesQuery).items?.[0]?.updates
+        : (res as GetBoardUpdatesQuery).boards?.[0]?.updates;
+      const updates = rawUpdates?.filter((update): update is NonNullable<typeof update> => update != null) || [];
 
-      if (!updates || updates.length === 0) {
+      if (updates.length === 0) {
         return {
           content: `No updates found for ${input.objectType.toLowerCase()} with id ${input.objectId}`,
         };


### PR DESCRIPTION
## Summary
- treat all-null update arrays the same as an empty updates result instead of letting null entries fall through to formatting
- filter update rows before deciding whether to return the standard no-updates message
- add regression coverage for the nullable updates path

## Testing
- `npx jest src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.test.ts`
- `npm run build`