### PR TITLE
fix(update_doc): ignore null created blocks

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.test.ts
@@ -395,6 +395,20 @@ describe('UpdateDocTool', () => {
     expect(result.content[0].text).toContain('[FAILED] create_block');
   });
 
+  it('throws when create_doc_blocks only contains null entries', async () => {
+    jest.spyOn(mocks, 'mockRequest').mockImplementation((query: string) => {
+      if (query.includes('mutation createDocBlocks')) return Promise.resolve({ create_doc_blocks: [null] });
+      return Promise.resolve({});
+    });
+
+    const result = await callToolByNameRawAsync('update_doc', {
+      doc_id: 'doc_123',
+      operations: [{ operation_type: 'create_block', block: { block_type: 'divider' } }],
+    });
+
+    expect(result.content[0].text).toContain('[FAILED] create_block');
+  });
+
   // ─── delete_block ────────────────────────────────────────────────────────
 
   it('executes delete_block operation', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.ts
@@ -271,8 +271,8 @@ COMMENTS:
     };
     const res = await this.mondayApi.request<CreateDocBlocksMutation>(createDocBlocks, variables);
 
-    const created = res?.create_doc_blocks;
-    if (!created || created.length === 0) {
+    const created = res?.create_doc_blocks?.filter((block): block is NonNullable<typeof block> => block != null) || [];
+    if (created.length === 0) {
       throw new Error('No blocks returned from create_doc_blocks');
     }
     const createdIds = created.map((b) => b.id).join(', ');


### PR DESCRIPTION
## Summary
- treat `create_doc_blocks: [null]` the same as an empty result instead of letting null entries fall through to ID formatting
- keep the existing error path but base it on non-null created blocks only
- add regression coverage for the all-null mutation response path

## Testing
- `npx jest src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.ts src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.test.ts`
- `npm run build`