### PR TITLE
fix(get_full_board_data): ignore null items

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts
@@ -5,7 +5,7 @@ import { ZodTypeAny } from 'zod';
 import { FullBoardDataToolSchema } from './full-board-data-tool';
 import { MondayAgentToolkit } from 'src/mcp/toolkit';
 
-export type inputType = z.objectInputType<FullBoardDataToolSchema, ZodTypeAny>;
+type inputType = z.objectInputType<FullBoardDataToolSchema, ZodTypeAny>;
 
 describe('Full Board Data Tool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
@@ -283,6 +283,41 @@ describe('Full Board Data Tool', () => {
     expect(parsedResult.users).toHaveLength(0);
 
     // Should only call board query since no valid creator IDs
+    expect(mocks.mockApiClient.request).toHaveBeenCalledTimes(1);
+  });
+
+  it('Skips null items in items_page before enriching data', async () => {
+    const boardWithNullItem = {
+      boards: [
+        {
+          id: '123456',
+          name: 'Test Board',
+          columns: [],
+          items_page: {
+            items: [
+              null,
+              {
+                id: '111',
+                name: 'Item 1',
+                column_values: [],
+                updates: [],
+              },
+            ],
+          },
+        },
+      ],
+    };
+
+    mocks.setResponse(boardWithNullItem);
+
+    const parsedResult = await callToolByNameAsync('get_full_board_data', {
+      boardId: '123456',
+    });
+
+    expect(parsedResult.board.items).toHaveLength(1);
+    expect(parsedResult.board.items[0].id).toBe('111');
+    expect(parsedResult.stats.total_items).toBe(1);
+    expect(parsedResult.stats.total_updates).toBe(0);
     expect(mocks.mockApiClient.request).toHaveBeenCalledTimes(1);
   });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts
@@ -68,11 +68,12 @@ export class FullBoardDataTool extends BaseMondayApiTool<typeof fullBoardDataToo
       }
 
       const board = boardData.boards[0];
+      const items = board.items_page.items.filter((item): item is NonNullable<typeof item> => item !== null);
 
       // Step 2: Extract unique user IDs from updates and people column values
       const userIds = new Set<string>();
 
-      board.items_page.items.forEach((item) => {
+      items.forEach((item) => {
         // Collect IDs from update creators and reply creators
         item.updates?.forEach((update) => {
           if (update.creator_id) {
@@ -121,7 +122,7 @@ export class FullBoardDataTool extends BaseMondayApiTool<typeof fullBoardDataToo
           id: board.id,
           name: board.name,
           columns: board.columns,
-          items: board.items_page.items.map((item) => ({
+          items: items.map((item) => ({
             id: item.id,
             name: item.name,
             column_values: item.column_values,
@@ -145,8 +146,8 @@ export class FullBoardDataTool extends BaseMondayApiTool<typeof fullBoardDataToo
         },
         users: users,
         stats: {
-          total_items: board.items_page.items.length,
-          total_updates: board.items_page.items.reduce((sum, item) => sum + (item.updates?.length || 0), 0),
+          total_items: items.length,
+          total_updates: items.reduce((sum, item) => sum + (item.updates?.length || 0), 0),
           total_unique_creators: users.length,
         },
       };

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.test.ts
@@ -395,6 +395,20 @@ describe('UpdateDocTool', () => {
     expect(result.content[0].text).toContain('[FAILED] create_block');
   });
 
+  it('throws when create_doc_blocks only contains null entries', async () => {
+    jest.spyOn(mocks, 'mockRequest').mockImplementation((query: string) => {
+      if (query.includes('mutation createDocBlocks')) return Promise.resolve({ create_doc_blocks: [null] });
+      return Promise.resolve({});
+    });
+
+    const result = await callToolByNameRawAsync('update_doc', {
+      doc_id: 'doc_123',
+      operations: [{ operation_type: 'create_block', block: { block_type: 'divider' } }],
+    });
+
+    expect(result.content[0].text).toContain('[FAILED] create_block');
+  });
+
   // ─── delete_block ────────────────────────────────────────────────────────
 
   it('executes delete_block operation', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.ts
@@ -271,8 +271,8 @@ COMMENTS:
     };
     const res = await this.mondayApi.request<CreateDocBlocksMutation>(createDocBlocks, variables);
 
-    const created = res?.create_doc_blocks;
-    if (!created || created.length === 0) {
+    const created = res?.create_doc_blocks?.filter((block): block is NonNullable<typeof block> => block != null) || [];
+    if (created.length === 0) {
       throw new Error('No blocks returned from create_doc_blocks');
     }
     const createdIds = created.map((b) => b.id).join(', ');


### PR DESCRIPTION
## Summary
- filter null items out of `items_page.items` before enriching updates, people, and stats in `get_full_board_data`
- keep user lookup and aggregate counts aligned with the filtered item list
- add regression coverage for a board response containing a null item entry

## Testing
- `npx jest src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts`
- `npm run build`