### PR TITLE
fix(board_insights): ignore null result rows

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-tool.test.ts
@@ -729,6 +729,28 @@ describe('Board Insights Tool', () => {
       expect(result.content).toBe('No board insights found for the given query.');
     });
 
+    it('should handle aggregate results containing only null entries', async () => {
+      const mockResponse = {
+        boards: [{ name: 'Test Board', url: 'https://test.monday.com/boards/123456' }],
+        aggregate: {
+          results: [null],
+        },
+      };
+
+      mocks.setResponseOnce(mockResponse);
+
+      const tool = new BoardInsightsTool(mocks.mockApiClient, 'fake_token');
+
+      const result = await tool.execute({
+        boardId: 123456,
+        aggregations: [{ columnId: 'status' }],
+        filtersOperator: ItemsQueryOperator.And,
+        limit: DEFAULT_LIMIT,
+      });
+
+      expect(result.content).toBe('No board insights found for the given query.');
+    });
+
     it('should handle different value types in results', async () => {
       const mockResponse = {
         boards: [{ name: 'Test Board', url: 'https://test.monday.com/boards/123456' }],

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-tool.ts
@@ -98,7 +98,9 @@ export class BoardInsightsTool extends BaseMondayApiTool<typeof boardInsightsToo
 
     const res = await this.mondayApi.request<AggregateBoardInsightsQuery>(boardInsights, variables);
 
-    const rows = (res.aggregate?.results ?? []).map((resultSet) => {
+    const rows = (res.aggregate?.results ?? [])
+      .filter((resultSet): resultSet is NonNullable<typeof resultSet> => resultSet !== null)
+      .map((resultSet) => {
       const row: Record<string, string | number | boolean | null> = {};
       (resultSet.entries ?? []).forEach((entry) => {
         const alias = entry.alias ?? '';


### PR DESCRIPTION
## Summary
- filter null aggregate result rows before formatting board insights data
- keep the existing empty-result behavior for all-null aggregate responses
- add regression coverage for aggregate results containing only null entries

## Testing
- `npx jest src/core/tools/platform-api-tools/board-insights/board-insights-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/board-insights/board-insights-tool.ts src/core/tools/platform-api-tools/board-insights/board-insights-tool.test.ts`
- `npm run build`