### PR TITLE
fix(read_docs): ignore null restoring points

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts
@@ -162,6 +162,15 @@ describe('ReadDocsTool', () => {
       expect(result.content[0].text).toContain(DOC_ID);
     });
 
+    it('should return no history message when restoring points only contain null entries', async () => {
+      mocks.setResponse({ doc_version_history: { doc_id: DOC_ID, restoring_points: [null] } });
+
+      const result = await callToolByNameRawAsync(TOOL_NAME, { mode: 'version_history', doc_id: DOC_ID });
+
+      expect(result.content[0].text).toContain('No version history found');
+      expect(result.content[0].text).toContain(DOC_ID);
+    });
+
     it('should pass since/until to the API', async () => {
       mocks.setResponse(mockHistoryResponse);
 
@@ -235,6 +244,23 @@ describe('ReadDocsTool', () => {
 
       expect(result.restoring_points[0].diff).toBeUndefined();
       expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore null restoring points before fetching diffs', async () => {
+      const pointsWithNullEntry = [
+        null,
+        { date: '2026-03-18T10:00:00Z', user_ids: ['1001'], type: null },
+        { date: '2026-03-17T09:00:00Z', user_ids: ['1001'], type: null },
+      ];
+      mocks.mockRequest
+        .mockResolvedValueOnce({ doc_version_history: { doc_id: DOC_ID, restoring_points: pointsWithNullEntry } })
+        .mockResolvedValueOnce(mockDiffResponse);
+
+      const result = await callToolByNameAsync(TOOL_NAME, { mode: 'version_history', doc_id: DOC_ID, include_diff: true });
+
+      expect(result.restoring_points).toHaveLength(2);
+      expect(result.restoring_points[0].diff).toEqual(mockDiffBlocks);
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(2);
     });
 
     it('should return error content on API errors', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts
@@ -190,9 +190,12 @@ MODE: "version_history" — Fetch the edit history of a single document.
       const variables: GetDocVersionHistoryQueryVariables = { docId: doc_id, since, until };
       const historyResult = await this.mondayApi.request<GetDocVersionHistoryQuery>(getDocVersionHistory, variables);
 
-      const restoringPoints = historyResult?.doc_version_history?.restoring_points;
+      const restoringPoints =
+        historyResult?.doc_version_history?.restoring_points?.filter(
+          (point): point is NonNullable<typeof point> => point !== null,
+        ) || [];
 
-      if (!restoringPoints || restoringPoints.length === 0) {
+      if (restoringPoints.length === 0) {
         return {
           content: `No version history found for document ${doc_id} in the specified time range (${since} to ${until}).`,
         };


### PR DESCRIPTION
## Summary
- filter null restoring points before handling `read_docs` version history results
- treat all-null restoring point arrays as no-history results
- add regression coverage for nullable restoring points in both the no-history and diff-fetch paths

## Testing
- `npx jest src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts`
- `npm run build`