### PR TITLE
fix(fetch_custom_activity): ignore null entries

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/fetch-custom-activity-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/fetch-custom-activity-tool.test.ts
@@ -1,0 +1,43 @@
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameRawAsync, createMockApiClient } from './test-utils/mock-api-client';
+
+describe('FetchCustomActivityTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns formatted custom activities', async () => {
+    mocks.setResponse({
+      custom_activity: [
+        {
+          id: 'activity_1',
+          name: 'Deal won',
+          color: 'green',
+          icon_id: 'icon_1',
+          type: 'crm',
+        },
+      ],
+    });
+
+    const result = await callToolByNameRawAsync('fetch_custom_activity', {});
+
+    expect(result.content[0].text).toContain('Found 1 custom activities');
+    expect(result.content[0].text).toContain('Deal won');
+  });
+
+  it('returns no custom activities when all entries are null', async () => {
+    mocks.setResponse({ custom_activity: [null] });
+
+    const result = await callToolByNameRawAsync('fetch_custom_activity', {});
+
+    expect(result.content[0].text).toBe('No custom activities found');
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/fetch-custom-activity-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/fetch-custom-activity-tool.ts
@@ -27,14 +27,15 @@ export class FetchCustomActivityTool extends BaseMondayApiTool<typeof fetchCusto
     input: ToolInputType<typeof fetchCustomActivityToolSchema>,
   ): Promise<ToolOutputType<never>> {
     const res = await this.mondayApi.request<FetchCustomActivityQuery>(fetchCustomActivity);
+    const activities = res.custom_activity?.filter((activity): activity is NonNullable<typeof activity> => activity !== null) || [];
 
-    if (!res.custom_activity || res.custom_activity.length === 0) {
+    if (activities.length === 0) {
       return {
         content: 'No custom activities found',
       };
     }
 
-    const activities = res.custom_activity.map((activity) => {
+    const formattedActivities = activities.map((activity) => {
       return {
         id: activity.id,
         name: activity.name,
@@ -45,7 +46,7 @@ export class FetchCustomActivityTool extends BaseMondayApiTool<typeof fetchCusto
     });
 
     return {
-      content: `Found ${activities.length} custom activities: ${JSON.stringify(activities, null, 2)}`,
+      content: `Found ${formattedActivities.length} custom activities: ${JSON.stringify(formattedActivities, null, 2)}`,
     };
   }
 }


### PR DESCRIPTION
## Summary
- filter null entries out of `fetch_custom_activity` results before formatting them
- treat all-null custom activity arrays as an empty result instead of returning a malformed success payload
- add focused regression coverage for both the success path and the all-null path

## Testing
- `npx jest src/core/tools/platform-api-tools/fetch-custom-activity-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/fetch-custom-activity-tool.ts src/core/tools/platform-api-tools/fetch-custom-activity-tool.test.ts`
- `npm run build`