### PR TITLE
fix(list_users_and_teams): ignore null section entries

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts
@@ -218,6 +218,28 @@ describe('ListUsersAndTeamsTool - Helper Functions', () => {
       expect(result).toBe('No users or teams found with the specified filters.');
     });
 
+    it('should treat users arrays with only null entries as empty', () => {
+      const mockData = {
+        users: [null],
+        teams: null,
+      } as unknown as FormattedResponse;
+
+      const result = formatUsersAndTeams(mockData);
+
+      expect(result).toBe('No users or teams found with the specified filters.');
+    });
+
+    it('should treat teams arrays with only null entries as empty', () => {
+      const mockData = {
+        users: null,
+        teams: [null],
+      } as unknown as FormattedResponse;
+
+      const result = formatUsersAndTeams(mockData);
+
+      expect(result).toBe('No users or teams found with the specified filters.');
+    });
+
     it('should handle multiple users and teams', () => {
       const mockData: FormattedResponse = {
         users: [

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams.utils.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams.utils.ts
@@ -1,4 +1,4 @@
-import { FormattedResponse, isExtendedTeam, UserTeam } from './types';
+import { FormattedResponse, isExtendedTeam } from './types';
 
 // Configuration for optional team member fields: [fieldName, displayLabel]
 const optionalTeamMemberFields: Array<[string, string]> = [
@@ -27,11 +27,13 @@ function formatOptionalUserFields(user: Record<string, any>, prefix = ''): strin
 
 export const formatUsersAndTeams = (data: FormattedResponse): string => {
   const sections: string[] = [];
+  const users = 'users' in data ? data.users?.filter((user) => user != null) : null;
+  const teams = 'teams' in data ? data.teams?.filter((team) => team != null) : null;
 
   // Format Users
-  if ('users' in data && data.users && data.users.length > 0) {
+  if (users && users.length > 0) {
     sections.push('Users:');
-    data.users.forEach((user) => {
+    users.forEach((user) => {
       if (user) {
         sections.push(`  ID: ${user.id}`);
         sections.push(`  Name: ${user.name}`);
@@ -59,9 +61,9 @@ export const formatUsersAndTeams = (data: FormattedResponse): string => {
   }
 
   // Format Teams
-  if ('teams' in data && data.teams && data.teams.length > 0) {
+  if (teams && teams.length > 0) {
     sections.push('Teams:');
-    data.teams.forEach((team) => {
+    teams.forEach((team) => {
       if (team) {
         sections.push(`  ID: ${team.id}`);
         sections.push(`  Name: ${team.name}`);


### PR DESCRIPTION
## Summary
- ignore all-null `users` and `teams` arrays before rendering `list_users_and_teams` output sections
- keep the formatter on the standard empty-result message instead of emitting empty section headers
- add regression coverage for all-null users and all-null teams responses

## Testing
- `npx jest src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams.utils.ts src/core/tools/platform-api-tools/list-users-and-teams-tool/list-users-and-teams-tool.test.ts`
- `npm run build`