### PR TITLE
fix(get_board_activity): ignore null activity logs

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.test.ts
@@ -1,0 +1,64 @@
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameAsync, callToolByNameRawAsync, createMockApiClient } from '../test-utils/mock-api-client';
+
+describe('GetBoardActivityTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns board activity data', async () => {
+    mocks.setResponse({
+      boards: [
+        {
+          name: 'Test Board',
+          url: 'https://test.monday.com/boards/123',
+          activity_logs: [
+            {
+              created_at: '2026-03-01T00:00:00Z',
+              event: 'update_column_value',
+              entity: 'pulse',
+              user_id: '123',
+              data: { before: 'old', after: 'new' },
+            },
+          ],
+        },
+      ],
+    });
+
+    const result = await callToolByNameAsync('get_board_activity', {
+      boardId: 123,
+      includeData: true,
+    });
+
+    expect(result.message).toBe('Board activity retrieved');
+    expect(result.data).toHaveLength(1);
+    expect(result.data[0].event).toBe('update_column_value');
+    expect(result.data[0].data).toEqual({ before: 'old', after: 'new' });
+  });
+
+  it('returns no activity when logs only contain null entries', async () => {
+    mocks.setResponse({
+      boards: [
+        {
+          name: 'Test Board',
+          url: 'https://test.monday.com/boards/123',
+          activity_logs: [null],
+        },
+      ],
+    });
+
+    const result = await callToolByNameRawAsync('get_board_activity', {
+      boardId: 123,
+    });
+
+    expect(result.content[0].text).toContain('No activity found for board 123');
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.ts
@@ -65,9 +65,11 @@ export class GetBoardActivityTool extends BaseMondayApiTool<typeof getBoardActiv
 
     const res = await this.mondayApi.request<GetBoardAllActivityQuery>(getBoardAllActivity, variables);
 
-    const activityLogs = res.boards?.[0]?.activity_logs;
+    const activityLogs = res.boards?.[0]?.activity_logs?.filter(
+      (log): log is NonNullable<typeof log> => log !== null && log !== undefined,
+    ) || [];
 
-    if (!activityLogs || activityLogs.length === 0) {
+    if (activityLogs.length === 0) {
       return {
         content: `No activity found for board ${input.boardId} in the specified time range (${fromDate} to ${toDate}).`,
       };
@@ -82,9 +84,7 @@ export class GetBoardActivityTool extends BaseMondayApiTool<typeof getBoardActiv
         board_id: input.boardId,
         board_name: board?.name,
         board_url: board?.url,
-        data: activityLogs
-          .filter((log): log is NonNullable<typeof log> => log !== null && log !== undefined)
-          .map((log) => ({
+        data: activityLogs.map((log) => ({
             created_at: log.created_at,
             event: log.event,
             entity: log.entity,


### PR DESCRIPTION
## Summary
- filter null activity log entries before deciding whether `get_board_activity` has results
- keep the existing no-activity message for all-null responses instead of returning an empty success payload
- add focused regression coverage for both a normal activity response and an all-null activity array

## Testing
- `npx jest src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.ts src/core/tools/platform-api-tools/get-board-activity/get-board-activity-tool.test.ts`
- `npm run build`