### PR TITLE
fix(add_content_to_doc): ignore null block ids

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.test.ts
@@ -264,6 +264,39 @@ describe('AddContentToDocTool', () => {
       expect(parsed.block_ids).toBeNull();
     });
 
+    it('should ignore null entries inside block_ids in successful response', async () => {
+      const getDocByIdResponse = {
+        docs: [{ id: 'doc_123', name: 'Test Doc', url: 'https://example.com/doc' }],
+      };
+
+      const addContentResponse = {
+        add_content_to_doc_from_markdown: {
+          success: true,
+          block_ids: [null, 'block_1'],
+          error: null,
+        },
+      };
+
+      jest.spyOn(mocks, 'mockRequest').mockImplementation((query: string) => {
+        if (query.includes('query getDocById')) {
+          return Promise.resolve(getDocByIdResponse);
+        }
+        if (query.includes('mutation addContentToDocFromMarkdown')) {
+          return Promise.resolve(addContentResponse);
+        }
+        return Promise.resolve({});
+      });
+
+      const result = await callToolByNameRawAsync('add_content_to_doc', {
+        doc_id: 'doc_123',
+        markdown: 'Content',
+      });
+
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed.message).toContain('1 block created');
+      expect(parsed.block_ids).toEqual(['block_1']);
+    });
+
     it('should return doc_name and doc_url in success response', async () => {
       const getDocByIdResponse = {
         docs: [{ id: 'doc_123', name: 'My Important Doc', url: 'https://example.com/my-doc' }],

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.ts
@@ -116,12 +116,13 @@ USAGE EXAMPLES:
         return { content: `Error adding content to document: ${error || 'Unknown error'}` };
       }
 
-      const blockCount = block_ids?.length ?? 0;
+      const filteredBlockIds = block_ids?.filter((blockId): blockId is NonNullable<typeof blockId> => blockId != null) ?? [];
+      const blockCount = filteredBlockIds.length;
       return {
         content: {
           message: `Successfully added content to document ${doc.id}. ${blockCount} block${blockCount === 1 ? '' : 's'} created.`,
           doc_id: doc.id,
-          block_ids: block_ids,
+          block_ids: filteredBlockIds.length > 0 ? filteredBlockIds : null,
           doc_name: doc.name,
           doc_url: doc.url,
         },


### PR DESCRIPTION
## Summary
- ignore null `block_ids` when formatting successful add-content-to-doc responses
- base the created block count and returned block ID list on non-null block ids only
- add regression coverage for successful mutation responses containing null block ids

## Testing
- `npx jest src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.test.ts`
- `npx eslint src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.ts src/core/tools/platform-api-tools/add-content-to-doc-tool/add-content-to-doc-tool.test.ts`
- `npm run build`