### PR TITLE
fix(get_board_info): ignore null columns

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts
@@ -443,6 +443,18 @@ describe('formatBoardInfoAsJson - views', () => {
     expect(result.board.views).toEqual([]);
   });
 
+  it('should handle null columns without throwing', () => {
+    const board: BoardInfoData = {
+      ...baseBoard,
+      columns: null,
+    } as unknown as BoardInfoData;
+
+    const result = formatBoardInfoAsJson(board, null) as any;
+
+    expect(result.board.columns).toBeNull();
+    expect(result.filteringGuidelines).toBe('');
+  });
+
   it('should return multiple views', () => {
     const board: BoardInfoData = {
       ...baseBoard,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/helpers.ts
@@ -19,12 +19,14 @@ export const formatBoardInfoAsJson = (
   board: BoardInfoData,
   subItemsBoard: BoardInfoJustColumnsData | null,
 ): BoardInfoResponse => {
+  const baseColumns = board.columns?.filter(isBaseColumnInfo) ?? [];
+
   return {
     board: {
       ...board,
       subItemColumns: subItemsBoard?.columns ?? undefined,
     },
-    filteringGuidelines: getColumnFilteringGuidelines(board.columns!.filter(isBaseColumnInfo) as BaseColumnInfo[]),
+    filteringGuidelines: getColumnFilteringGuidelines(baseColumns as BaseColumnInfo[]),
     aggregationGuidelines: getColumnAggregationGuidelines(),
   };
 };


### PR DESCRIPTION
## Summary
- treat `get_board_info` boards with `columns: null` as having no filterable columns instead of throwing in JSON formatting
- add a regression test covering the nullable `columns` response shape

## Testing
- npx jest src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts
- npx eslint src/core/tools/platform-api-tools/get-board-info/helpers.ts src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts
- npm run build