### PR TITLE
fix(search): ignore null result entries

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
@@ -6,7 +6,7 @@ import { GetBoardsQuery, GetDocsQuery, GetFoldersQuery } from 'src/monday-graphq
 import { SearchDevQuery, SearchableEntity } from 'src/monday-graphql/generated/graphql.dev/graphql';
 import { GlobalSearchType, ObjectPrefixes, SearchResult, BOARD_SEARCH_RESULT_TYPENAME, DOC_SEARCH_RESULT_TYPENAME } from './search-tool.types';
 
-export type inputType = z.objectInputType<typeof searchSchema, ZodTypeAny>;
+type inputType = z.objectInputType<typeof searchSchema, ZodTypeAny>;
 
 describe('SearchTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
@@ -250,6 +250,29 @@ describe('SearchTool', () => {
         const parsedResult = await callToolByNameAsync('search', args);
 
         expect(parsedResult.data).toHaveLength(0);
+      });
+
+      it('should ignore null board entries', async () => {
+        const responseWithNullBoard: GetBoardsQuery = {
+          boards: [
+            { id: '123', name: 'Test Board 1', url: 'https://monday.com/boards/123' },
+            null as any,
+            { id: '456', name: 'Test Board 2', url: 'https://monday.com/boards/456' },
+          ],
+        };
+
+        mocks.setResponse(responseWithNullBoard);
+
+        const args: inputType = {
+          searchType: GlobalSearchType.BOARD,
+        };
+
+        const parsedResult = await callToolByNameAsync('search', args);
+
+        expect(parsedResult.data).toEqual([
+          { id: 'board-123', title: 'Test Board 1', url: 'https://monday.com/boards/123' },
+          { id: 'board-456', title: 'Test Board 2', url: 'https://monday.com/boards/456' },
+        ]);
       });
 
       it('should properly prefix board IDs', async () => {
@@ -728,6 +751,29 @@ describe('SearchTool', () => {
         expect(parsedResult.data).toHaveLength(0);
       });
 
+      it('should ignore null document entries', async () => {
+        const responseWithNullDoc: GetDocsQuery = {
+          docs: [
+            { id: '111', name: 'Document 1', url: 'https://monday.com/docs/111' },
+            null as any,
+            { id: '222', name: 'Document 2', url: 'https://monday.com/docs/222' },
+          ],
+        };
+
+        mocks.setResponse(responseWithNullDoc);
+
+        const args: inputType = {
+          searchType: GlobalSearchType.DOCUMENTS,
+        };
+
+        const parsedResult = await callToolByNameAsync('search', args);
+
+        expect(parsedResult.data).toEqual([
+          { id: 'doc-111', title: 'Document 1', url: 'https://monday.com/docs/111' },
+          { id: 'doc-222', title: 'Document 2', url: 'https://monday.com/docs/222' },
+        ]);
+      });
+
       it('should properly prefix document IDs', async () => {
         mocks.setResponse(mockDocsResponse);
 
@@ -980,6 +1026,30 @@ describe('SearchTool', () => {
         const parsedResult = await callToolByNameAsync('search', args);
 
         expect(parsedResult.data).toHaveLength(0);
+      });
+
+      it('should ignore null folder entries', async () => {
+        const responseWithNullFolder: GetFoldersQuery = {
+          folders: [
+            { id: '100', name: 'Folder 1' },
+            null as any,
+            { id: '200', name: 'Folder 2' },
+          ],
+        };
+
+        mocks.setResponse(responseWithNullFolder);
+
+        const args: inputType = {
+          searchType: GlobalSearchType.FOLDERS,
+          workspaceIds: [1],
+        };
+
+        const parsedResult = await callToolByNameAsync('search', args);
+
+        expect(parsedResult.data).toEqual([
+          { id: 'folder-100', title: 'Folder 1' },
+          { id: 'folder-200', title: 'Folder 2' },
+        ]);
       });
 
       it('should properly prefix folder IDs', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.ts
@@ -166,12 +166,12 @@ IMPORTANT: ids returned by this tool are prefixed with the type of the object (e
     }
 
     const response = await this.mondayApi.request<GetFoldersQuery>(getFolders, variables);
-    const data = this.searchAndVirtuallyPaginate(input, response.folders || [], (folder) => folder!.name);
+    const data = this.searchAndVirtuallyPaginate(input, (response.folders || []).filter(isDefined), (folder) => folder.name);
 
     const result = {
       items: data.items.map((folder) => ({
-        id: ObjectPrefixes.FOLDER + folder!.id,
-        title: folder!.name,
+        id: ObjectPrefixes.FOLDER + folder.id,
+        title: folder.name,
       })),
       wasFiltered: data.wasFiltered,
     };
@@ -186,13 +186,13 @@ IMPORTANT: ids returned by this tool are prefixed with the type of the object (e
     };
 
     const response = await this.mondayApi.request<GetDocsQuery>(getDocs, variables);
-    const data = this.searchAndVirtuallyPaginate(input, response.docs || [], (doc) => doc!.name);
+    const data = this.searchAndVirtuallyPaginate(input, (response.docs || []).filter(isDefined), (doc) => doc.name);
 
     const result = {
       items: data.items.map((doc) => ({
-        id: ObjectPrefixes.DOCUMENT + doc!.id,
-        title: doc!.name,
-        url: doc!.url || undefined,
+        id: ObjectPrefixes.DOCUMENT + doc.id,
+        title: doc.name,
+        url: doc.url || undefined,
       })),
       wasFiltered: data.wasFiltered,
     };
@@ -207,13 +207,13 @@ IMPORTANT: ids returned by this tool are prefixed with the type of the object (e
     };
 
     const response = await this.mondayApi.request<GetBoardsQuery>(getBoards, variables);
-    const data = this.searchAndVirtuallyPaginate(input, response.boards || [], (board) => board!.name);
+    const data = this.searchAndVirtuallyPaginate(input, (response.boards || []).filter(isDefined), (board) => board.name);
 
     const result = {
       items: data.items.map((board) => ({
-        id: ObjectPrefixes.BOARD + board!.id,
-        title: board!.name,
-        url: board!.url,
+        id: ObjectPrefixes.BOARD + board.id,
+        title: board.name,
+        url: board.url,
       })),
       wasFiltered: data.wasFiltered,
     };
@@ -247,4 +247,8 @@ IMPORTANT: ids returned by this tool are prefixed with the type of the object (e
 
     return { items: filteredItems, wasFiltered: true };
   }
+}
+
+function isDefined<T>(value: T | null | undefined): value is T {
+  return value != null;
 }


### PR DESCRIPTION
## Summary
- filter out null board, document, and folder entries before search-tool mapping/pagination dereferences them
- add focused regressions covering nullable entries in all three search handlers

## Testing
- npx jest src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
- npx eslint src/core/tools/platform-api-tools/search-tool/search-tool.ts src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
- npm run build