### PR TITLE
fix: remove unsafe characters from tool descriptions

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.0.1",
+  "version": "5.0.2",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts
@@ -27,7 +27,7 @@ export class GetBoardInfoTool extends BaseMondayApiTool<typeof getBoardInfoToolS
   getDescription(): string {
     return (
       'Get comprehensive board information including metadata, structure, owners, and configuration. ' +
-      'Also returns the board\'s views (e.g. table views, filter views) — each view includes its id, name, type, and a structured `filter` object. '
+      'Also returns the board\'s views (e.g. table views, filter views) — each view includes its id, name, type, and a structured filter object. '
     );
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-items-page-tool/get-board-items-page-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-items-page-tool/get-board-items-page-tool.ts
@@ -145,12 +145,12 @@ export class GetBoardItemsPageTool extends BaseMondayApiTool<GetBoardItemsPageTo
 
   getDescription(): string {
     return (
-      `Get all items from a monday.com board with pagination support and optional column values and item descriptions. ` +
-      `Returns structured JSON with item details, creation/update timestamps, and pagination info. ` +
-      `Use the 'nextCursor' parameter from the response to get the next page of results when 'has_more' is true. ` +
-      `To retrieve an item's description (the rich-text body/details of a monday.com item), set 'includeItemDescription' to true — the response will include the item description's document blocks with their content, type, and id. Use this whenever the user asks about an item's description, body, details, or notes. ` +
-      `[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board's structure (column IDs, column types, status labels, etc.), first use get_board_info to understand the board metadata. This is essential for constructing proper filters and knowing which columns are available. ` +
-      `VIEW-BASED FILTERING: If the user refers to a board view by name (e.g. "show me items in the 'Overdue' view"), first call get_board_info to get the board's views, find the matching view by name, then extract its filter field and pass it as the filters argument here.`
+      'Get all items from a monday.com board with pagination support and optional column values and item descriptions. ' +
+      'Returns structured JSON with item details, creation/update timestamps, and pagination info. ' +
+      'Use the nextCursor parameter from the response to get the next page of results when has_more is true. ' +
+      'To retrieve an item description (the rich-text body/details of a monday.com item), set includeItemDescription to true — the response will include the item description document blocks with their content, type, and id. Use this whenever the user asks about an item description, body, details, or notes. ' +
+      '[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board structure (column IDs, column types, status labels, etc.), first use get_board_info to understand the board metadata. This is essential for constructing proper filters and knowing which columns are available. ' +
+      'VIEW-BASED FILTERING: If the user refers to a board view by name (e.g. "show me items in the Overdue view"), first call get_board_info to get the board views, find the matching view by name, then extract its filter field and pass it as the filters argument here.'
     );
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-updates-tool/get-updates-tool.ts
@@ -72,7 +72,7 @@ export class GetUpdatesTool extends BaseMondayApiTool<typeof getUpdatesToolSchem
       'Get updates (comments/posts) from a monday.com item or board. ' +
       'Specify objectId and objectType (Item or Board) to retrieve updates. ' +
       'For Board queries, you can filter by date range using fromDate and toDate (both required together, ISO8601 format). ' +
-      'By default, Board queries return only board discussion; set includeItemUpdates to true to also include updates on individual items. ' +
+      'By default, Board queries return only board discussion. Set includeItemUpdates to true to also include updates on individual items. ' +
       'Returns update text, creator info, timestamps, and optionally replies and assets.'
     );
   }

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/move-object-tool/move-object-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/move-object-tool/move-object-tool.ts
@@ -51,7 +51,7 @@ export class MoveObjectTool extends BaseMondayApiTool<MoveObjectToolInput> {
   });
 
   getDescription(): string {
-    return 'Move a folder, board, or overview in monday.com. Use `position` for relative placement based on another object, `parentFolderId` for folder changes, `workspaceId` for workspace moves, and `accountProductId` for account product changes.';
+    return 'Move a folder, board, or overview in monday.com. Use position for relative placement based on another object, parentFolderId for folder changes, workspaceId for workspace moves, and accountProductId for account product changes.';
   }
 
   getInputSchema(): MoveObjectToolInput {


### PR DESCRIPTION
Some MCP clients (e.g. IBM watsonx Orchestrate) reject tool descriptions containing backticks and semicolons as potential injection vectors. Remove these characters from get_board_info, get_board_items_page, get_updates, and move_object tool descriptions.