### PR TITLE
feat(agent-toolkit): add universal SLI tracking to platform API tools

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/base-monday-api-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/base-monday-api-tool.ts
@@ -3,6 +3,7 @@ import { ZodRawShape } from 'zod';
 import { ToolAnnotations } from '@modelcontextprotocol/sdk/types';
 import { SessionContext } from '../../executable';
 import { Tool, ToolInputType, ToolOutputType, ToolType } from '../../tool';
+import { trackEvent } from '../../../utils/tracking.utils';
 
 export type MondayApiToolContext = {
   // Operational context
@@ -46,11 +47,36 @@ export abstract class BaseMondayApiTool<
   abstract getInputSchema(): Input;
 
   /**
-   * Public execute method
+   * Public execute method that automatically tracks SLI events
    */
   async execute(input?: ToolInputType<Input>, sessionContext?: SessionContext): Promise<ToolOutputType<Output>> {
     this.sessionContext = sessionContext || {};
-    return this.executeInternal(input);
+    const startTime = Date.now();
+
+    trackEvent({
+      name: `mcp_sli_${this.name}_request`,
+      data: { toolName: this.name },
+    });
+
+    try {
+      const result = await this.executeInternal(input);
+
+      trackEvent({
+        name: `mcp_sli_${this.name}_success`,
+        data: { toolName: this.name, executionTimeMs: Date.now() - startTime },
+      });
+
+      return result;
+    } catch (error) {
+      trackEvent({
+        name: `mcp_sli_${this.name}_failure`,
+        data: {
+          toolName: this.name,
+          executionTimeMs: Date.now() - startTime,
+        },
+      });
+      throw error;
+    }
   }
 
   /**

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/base-monday-api-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/base-monday-api-tool.ts
@@ -47,7 +47,7 @@ export abstract class BaseMondayApiTool<
   abstract getInputSchema(): Input;
 
   /**
-   * Public execute method that automatically tracks SLI events
+   * Public execute method
    */
   async execute(input?: ToolInputType<Input>, sessionContext?: SessionContext): Promise<ToolOutputType<Output>> {
     this.sessionContext = sessionContext || {};

--- a/packages/agent-toolkit/src/utils/tracking.utils.ts
+++ b/packages/agent-toolkit/src/utils/tracking.utils.ts
@@ -20,7 +20,7 @@ export const trackEvent = ({ name, data }: { name: string; data: Record<string, 
         },
       },
     )
-    .catch(() => {
+    ?.catch(() => {
       // ignore errors in tracking
     });
 };


### PR DESCRIPTION
Emit `mcp_sli_{toolName}_request`, `_success`, and `_failure` BigBrain events from `BaseMondayApiTool.execute()` so every platform API tool is automatically instrumented for SLO measurement.

Also hardens `trackEvent` with optional chaining so a mocked or unexpected `axios.post` return value does not throw.