### PR TITLE
chore(agent-toolkit): bump version to 5.3.1

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## 5.4.0
+## 5.3.1
 
 ### Workforms tools — return full option data from GraphQL queries
 

--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.4.0
+
+### Workforms tools — return full option data from GraphQL queries
+
+- Added `value`, `visible`, and `active` fields to the `QuestionOptionsFragment` GraphQL fragment
+- `get_form`, `create_form_question`, and `update_form_question` now return complete option data
+- Previously only `label` was returned, preventing safe updates on questions with existing submissions
+
 ## 5.1.1
 
 ### Workforms tools — options schema and description updates

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.4.0",
+  "version": "5.3.1",
 
 
   "description": "monday.com agent toolkit",

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.3.0",
+  "version": "5.4.0",
 
 
   "description": "monday.com agent toolkit",


### PR DESCRIPTION
## Summary
- Bump `@mondaydotcomorg/agent-toolkit` from 5.3.0 to 5.3.1
- Updated CHANGELOG with the QuestionOptionsFragment fix (value, visible, active fields)

## Monday Item
https://monday.monday.com/boards/3709356818/pulses/11453478027

## Test Plan
- [ ] Verify package version is 5.3.1 in published artifact

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)