### PR TITLE
fix(agent-toolkit): make include filter the sole authority for tool selection

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,8 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.3.2",
-
-
+  "version": "5.3.3",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/utils/tools/tools-filtering.utils.ts
+++ b/packages/agent-toolkit/src/utils/tools/tools-filtering.utils.ts
@@ -22,6 +22,11 @@ export const getFilteredToolInstances = (
       return toolInstance.type !== ToolType.ALL_API;
     }
 
+    // When an explicit include list is provided, it is the sole authority
+    if (config.include) {
+      return config.include.includes(toolInstance.name);
+    }
+
     if (config.mode === ToolMode.API) {
       if (config.enableDynamicApiTools === 'only') {
         return toolInstance.type === ToolType.ALL_API;
@@ -35,10 +40,8 @@ export const getFilteredToolInstances = (
     if (config.readOnlyMode) {
       shouldFilter = shouldFilter || toolInstance.type !== ToolType.READ;
     }
-    if (config.include) {
-      shouldFilter = shouldFilter || !config.include?.includes(toolInstance.name);
-    } else if (config.exclude) {
-      shouldFilter = shouldFilter || config.exclude?.includes(toolInstance.name);
+    if (config.exclude) {
+      shouldFilter = shouldFilter || config.exclude.includes(toolInstance.name);
     }
     return !shouldFilter;
   });

--- a/packages/monday-api-mcp/package.json
+++ b/packages/monday-api-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/monday-api-mcp",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "MCP server for using the monday.com API",
   "mcpName": "com.monday/monday.com",
   "license": "MIT",


### PR DESCRIPTION
## Summary

- **Bug**: When `toolsConfiguration.include` was specified, the filter was OR-accumulated with other config flags (`readOnlyMode`, `enableDynamicApiTools: false`). This meant earlier filters could exclude tools that were explicitly listed in `include`, resulting in consumers (e.g. hosted-mcp) receiving a random subset of ~20 tools instead of their requested list.
- **Fix**: Move the `include` check to an early return before all other filters, making it the single source of truth when provided. If `include` is set, a tool is returned **if and only if** it appears in the list — no other filter can override that.
- All existing tests pass (48/48).

## Test plan

- [ ] Verify `include: ['search', 'get_board_items', ...]` returns exactly those tools
- [ ] Verify `exclude` still works when `include` is not set
- [ ] Verify `readOnlyMode` and `enableDynamicApiTools` still apply when `include` is not set
- [ ] Deploy to staging and confirm hosted-mcp receives the full `DEFAULT_TOOLS` list


Made with [Cursor](https://cursor.com)