### PR TITLE
automate bundle

### DIFF
--- a/packages/agent-toolkit/rollup.config.js
+++ b/packages/agent-toolkit/rollup.config.js
@@ -1,3 +1,4 @@
+import { createRequire } from 'module';
 import resolve from '@rollup/plugin-node-resolve';
 import commonjs from '@rollup/plugin-commonjs';
 import typescript from '@rollup/plugin-typescript';
@@ -5,6 +6,14 @@ import terser from '@rollup/plugin-terser';
 import json from '@rollup/plugin-json';
 import del from 'rollup-plugin-delete';
 import dts from 'rollup-plugin-dts';
+
+const require = createRequire(import.meta.url);
+const pkg = require('./package.json');
+
+const external = [
+  ...Object.keys(pkg.dependencies || {}),
+  ...Object.keys(pkg.peerDependencies || {}),
+];
 
 const subPaths = ['mcp', 'core', 'openai'];
 
@@ -37,7 +46,7 @@ const subpathConfigs = subPaths.map((dir) => ({
     json(),
     terser(),
   ].filter(Boolean),
-  external: ['@mondaydotcomorg/api', 'zod', 'zod-to-json-schema'],
+  external,
 }));
 
 // Subpath types


### PR DESCRIPTION
## Summary

Derive rollup `external` list automatically from `package.json` instead of maintaining a hardcoded duplicate list.

### Why

Previously, the `external` array in `rollup.config.js` was a hardcoded list (`['@mondaydotcomorg/api', 'zod', 'zod-to-json-schema']`). This meant every time a dependency was added to `package.json`, it also had to be manually added to the rollup config — and forgetting to do so would silently bundle it instead of externalizing it (this was already the case for `axios` and `jsonwebtoken`).

Now `external` is derived from `pkg.dependencies` and `pkg.peerDependencies`, so new dependencies are automatically externalized with no extra step.

### Note on `createRequire`

We use `createRequire` to load `package.json` because this project uses Rollup 2, which doesn't support JSON import assertions (`import pkg from './package.json' with { type: 'json' }`). This is the standard Node.js workaround for importing JSON in ES modules.