### PR TITLE
fix(form-questions-editor): remove existing_column_id and lock ConditionOperator to OR

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/form-questions-editor-tool/schema.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/form-questions-editor-tool/schema.ts
@@ -19,7 +19,7 @@ const questionSchema = z.object({
     .nullish()
     .describe(GraphQLDescriptions.question.properties.insertAfterQuestionId),
   page_block_id: z.string().nullish().describe(GraphQLDescriptions.question.properties.pageBlockId),
-  existing_column_id: z.string().describe(GraphQLDescriptions.question.properties.existingColumnId).optional(),
+
   show_if_rules: z
     .object({
       operator: z.nativeEnum(ConditionOperator),

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/workforms.consts.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/workforms.consts.ts
@@ -110,10 +110,9 @@ export const GraphQLDescriptions = {
       insertAfterQuestionId: 'ID to insert after. Omit to append. Null for first position.',
       pageBlockId:
         'Page block ID to group this question within. Set to null to remove from page block. Omit to leave unchanged.',
-      existingColumnId:
-        'Links this question to an existing board column instead of creating a new one. Omit to auto-create a column. Only send when explicitly asked.',
+
     },
-    showIfRules: 'Conditional visibility. OR between rules, AND between conditions within a rule.',
+    showIfRules: 'Conditional visibility. All operators must be OR.',
 
     showIfConditionBuildingBlockId: 'Question ID to evaluate.',
     showIfConditionValues: 'Answer values that satisfy the condition.',

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/workforms.types.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/workforms.types.ts
@@ -106,7 +106,6 @@ enum PrefillAccountLookups {
 }
 
 enum ConditionOperator {
-  And = 'AND',
   Or = 'OR',
 }
 


### PR DESCRIPTION
## Summary

- Remove `existing_column_id` from the `form_questions_editor` tool schema — this single field was responsible for 38% of all tool errors (700 ColumnNotFound + 65 QuestionTypeIncompatibleWithColumnType) as agents were passing arbitrary board column IDs not linked to the form
- Fix misleading `show_if_rules` description that incorrectly stated AND was used between conditions — all operators must be OR per the GraphQL schema
- Remove `And` from the local `ConditionOperator` enum in `workforms.types.ts` to align with the GraphQL schema constraint

## Monday Item
https://monday.monday.com/boards/3709356818/pulses/11453478027

## Test Plan
- Build passes: `npm run build`
- Type-check passes: `tsc --noEmit` (no errors in workforms files)
- Verify agents no longer attempt to use `existing_column_id` — field is absent from the tool's JSON schema

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
