### PR TITLE
chore(agent-toolkit): bump version to 5.7.1

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.7.1
+
+### form_questions_editor — fix ConditionOperator and remove existing_column_id
+
+- Removed `existing_column_id` from the tool schema — this field caused 38% of all tool errors (ColumnNotFound / QuestionTypeIncompatibleWithColumnType) because agents passed arbitrary board column IDs not linked to the form
+- Fixed misleading `show_if_rules` description that incorrectly stated AND was used between conditions — all operators must be OR per the GraphQL schema
+- Removed `And` from the local `ConditionOperator` enum to align with the GraphQL schema constraint
+
 ## 5.7.0
 
 ### Add account context to get_user_context tool

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.7.0",
+  "version": "5.7.1",
 
 
   "description": "monday.com agent toolkit",


### PR DESCRIPTION
## Summary

- Bump `@mondaydotcomorg/agent-toolkit` version from `5.7.0` → `5.7.1`
- Add CHANGELOG entry documenting the fix from PR #328

This was missed when #328 was merged — the version and changelog were not updated.

## Monday Item
https://monday.monday.com/boards/3709356818/pulses/11453478027

## Test Plan
- `npm run build` passes (no code changes, only version metadata)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
