### PR TITLE
fix(create_form_submission): replace .positive() with .min(1) on rating field

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/create-submission-tool/schema.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/create-submission-tool/schema.ts
@@ -50,6 +50,7 @@ const fileAnswerSchema = z.object({
   is_image: z.boolean().optional().describe('Whether the file is an image.'),
 });
 
+
 const formAnswerInputSchema = z
   .object({
     question_id: z.string().describe('The ID of the question being answered.'),
@@ -63,7 +64,7 @@ const formAnswerInputSchema = z
     number: z.number().optional().describe('Answer for number questions.'),
     rating: z
       .number()
-      .positive()
+      .min(1)
       .optional()
       .describe("Answer for rating questions. Must be a positive number within the question's configured limit."),
     single_select: z.string().optional().describe('Answer for single-select questions — the selected option ID.'),


### PR DESCRIPTION
## Problem

`z.number().positive()` and `z.number().min(1)` are semantically equivalent in Zod, but they produce **different JSON Schema output**:

| Zod | JSON Schema output |
|-----|-------------------|
| `z.number().positive()` | `{ "type": "number", "exclusiveMinimum": 0 }` |
| `z.number().min(1)` | `{ "type": "number", "minimum": 1 }` |

The difference: `exclusiveMinimum` is a **Draft-04** keyword where the value is a boolean, but `zod-to-json-schema` emits it as a **Draft-07** integer. Microsoft Copilot Studio expects boolean `exclusiveMinimum` (Draft-04 semantics) and throws a `System.FormatException` when it encounters an integer value — crashing the entire `tools/list` discovery response and making **all** MCP tools disappear for Copilot users.

## Fix

Replace `.positive()` with `.min(1)` on the `rating` field in `create_form_submission`. Both enforce the same constraint (rating must be ≥ 1), but `min(1)` emits the Copilot-compatible `minimum: 1` keyword.

## Test plan

- [x] Connect a local hosted-mcp with `create_form_submission` enabled to Microsoft Copilot Studio — all tools should appear in discovery
- [x] Verify `rating` still rejects values < 1 at runtime