### PR TITLE
feat(agent-toolkit): support owners in create_board tool

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.test.ts
@@ -1,0 +1,55 @@
+import { createMockApiClient } from './test-utils/mock-api-client';
+import { CreateBoardTool } from './create-board-tool';
+
+describe('CreateBoardTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    mocks = createMockApiClient();
+    jest.clearAllMocks();
+  });
+
+  const successfulResponse = {
+    create_board: {
+      id: '123456',
+      name: 'Test Board',
+      url: 'https://monday.com/boards/123456',
+    },
+  };
+
+  it('includes owners in variables when owners are provided', async () => {
+    mocks.setResponse(successfulResponse);
+    const tool = new CreateBoardTool(mocks.mockApiClient);
+
+    await tool.execute({
+      boardName: 'Test Board',
+      boardKind: 'public',
+      owners: ['111', '222'],
+    });
+
+    expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createBoard'), {
+      boardName: 'Test Board',
+      boardKind: 'public',
+      boardDescription: undefined,
+      workspaceId: undefined,
+      owners: ['111', '222'],
+    });
+  });
+
+  it('does not include owners in variables when owners are not provided', async () => {
+    mocks.setResponse(successfulResponse);
+    const tool = new CreateBoardTool(mocks.mockApiClient);
+
+    await tool.execute({
+      boardName: 'Test Board',
+      boardKind: 'public',
+    });
+
+    expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createBoard'), {
+      boardName: 'Test Board',
+      boardKind: 'public',
+      boardDescription: undefined,
+      workspaceId: undefined,
+    });
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.test.ts
@@ -1,5 +1,6 @@
 import { createMockApiClient } from './test-utils/mock-api-client';
 import { CreateBoardTool } from './create-board-tool';
+import { BoardKind } from '../../../monday-graphql/generated/graphql/graphql';
 
 describe('CreateBoardTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
@@ -17,37 +18,37 @@ describe('CreateBoardTool', () => {
     },
   };
 
-  it('includes owners in variables when owners are provided', async () => {
+  it('includes boardOwnerIds in variables when provided', async () => {
     mocks.setResponse(successfulResponse);
     const tool = new CreateBoardTool(mocks.mockApiClient);
 
     await tool.execute({
       boardName: 'Test Board',
-      boardKind: 'public',
-      owners: ['111', '222'],
+      boardKind: BoardKind.Public,
+      boardOwnerIds: ['111', '222'],
     });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createBoard'), {
       boardName: 'Test Board',
-      boardKind: 'public',
+      boardKind: BoardKind.Public,
       boardDescription: undefined,
       workspaceId: undefined,
-      owners: ['111', '222'],
+      boardOwnerIds: ['111', '222'],
     });
   });
 
-  it('does not include owners in variables when owners are not provided', async () => {
+  it('does not include boardOwnerIds in variables when not provided', async () => {
     mocks.setResponse(successfulResponse);
     const tool = new CreateBoardTool(mocks.mockApiClient);
 
     await tool.execute({
       boardName: 'Test Board',
-      boardKind: 'public',
+      boardKind: BoardKind.Public,
     });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createBoard'), {
       boardName: 'Test Board',
-      boardKind: 'public',
+      boardKind: BoardKind.Public,
       boardDescription: undefined,
       workspaceId: undefined,
     });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
@@ -13,7 +13,7 @@ export const createBoardToolSchema = {
   boardKind: z.nativeEnum(BoardKind).default(BoardKind.Public).describe('The kind of board to create'),
   boardDescription: z.string().optional().describe('The description of the board to create'),
   workspaceId: z.string().optional().describe('The ID of the workspace to create the board in'),
-  owners: z.array(z.string()).optional().describe('Optional list of user IDs to set as board owners'),
+  boardOwnerIds: z.array(z.string()).optional().describe('Optional list of user IDs to set as board owners'),
 };
 
 export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSchema, never> {
@@ -40,7 +40,7 @@ export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSch
       boardKind: input.boardKind,
       boardDescription: input.boardDescription,
       workspaceId: input.workspaceId,
-      ...(input.owners !== undefined ? { owners: input.owners } : {}),
+      ...(input.boardOwnerIds !== undefined ? { boardOwnerIds: input.boardOwnerIds } : {}),
     };
 
     const res = await this.mondayApi.request<CreateBoardMutation>(createBoard, variables);

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
@@ -27,7 +27,7 @@ export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSch
   });
 
   getDescription(): string {
-    return 'Create a monday.com board, optionally setting owner user IDs';
+    return 'Create a monday.com board';
   }
 
   getInputSchema(): typeof createBoardToolSchema {
@@ -40,7 +40,7 @@ export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSch
       boardKind: input.boardKind,
       boardDescription: input.boardDescription,
       workspaceId: input.workspaceId,
-      owners: input.owners,
+      ...(input.owners !== undefined ? { owners: input.owners } : {}),
     };
 
     const res = await this.mondayApi.request<CreateBoardMutation>(createBoard, variables);

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
@@ -13,6 +13,7 @@ export const createBoardToolSchema = {
   boardKind: z.nativeEnum(BoardKind).default(BoardKind.Public).describe('The kind of board to create'),
   boardDescription: z.string().optional().describe('The description of the board to create'),
   workspaceId: z.string().optional().describe('The ID of the workspace to create the board in'),
+  owners: z.array(z.string()).optional().describe('Optional list of user IDs to set as board owners'),
 };
 
 export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSchema, never> {
@@ -26,7 +27,7 @@ export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSch
   });
 
   getDescription(): string {
-    return 'Create a monday.com board';
+    return 'Create a monday.com board, optionally setting owner user IDs';
   }
 
   getInputSchema(): typeof createBoardToolSchema {
@@ -39,6 +40,7 @@ export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSch
       boardKind: input.boardKind,
       boardDescription: input.boardDescription,
       workspaceId: input.workspaceId,
+      owners: input.owners,
     };
 
     const res = await this.mondayApi.request<CreateBoardMutation>(createBoard, variables);

--- a/packages/agent-toolkit/src/monday-graphql/generated/graphql/graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/generated/graphql/graphql.ts
@@ -12249,6 +12249,7 @@ export type CreateBoardMutationVariables = Exact<{
   boardName: Scalars['String']['input'];
   boardDescription?: InputMaybe<Scalars['String']['input']>;
   workspaceId?: InputMaybe<Scalars['ID']['input']>;
+  owners?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
 }>;
 
 

--- a/packages/agent-toolkit/src/monday-graphql/generated/graphql/graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/generated/graphql/graphql.ts
@@ -12249,7 +12249,7 @@ export type CreateBoardMutationVariables = Exact<{
   boardName: Scalars['String']['input'];
   boardDescription?: InputMaybe<Scalars['String']['input']>;
   workspaceId?: InputMaybe<Scalars['ID']['input']>;
-  owners?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
+  boardOwnerIds?: InputMaybe<Array<Scalars['ID']['input']> | Scalars['ID']['input']>;
 }>;
 
 

--- a/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
@@ -63,12 +63,19 @@ export const moveItemToGroup = gql`
 `;
 
 export const createBoard = gql`
-  mutation createBoard($boardKind: BoardKind!, $boardName: String!, $boardDescription: String, $workspaceId: ID) {
+  mutation createBoard(
+    $boardKind: BoardKind!
+    $boardName: String!
+    $boardDescription: String
+    $workspaceId: ID
+    $owners: [ID!]
+  ) {
     create_board(
       board_kind: $boardKind
       board_name: $boardName
       description: $boardDescription
       workspace_id: $workspaceId
+      owners: $owners
       empty: true
     ) {
       id

--- a/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
+++ b/packages/agent-toolkit/src/monday-graphql/queries.graphql.ts
@@ -68,14 +68,14 @@ export const createBoard = gql`
     $boardName: String!
     $boardDescription: String
     $workspaceId: ID
-    $owners: [ID!]
+    $boardOwnerIds: [ID!]
   ) {
     create_board(
       board_kind: $boardKind
       board_name: $boardName
       description: $boardDescription
       workspace_id: $workspaceId
-      owners: $owners
+      board_owner_ids: $boardOwnerIds
       empty: true
     ) {
       id


### PR DESCRIPTION
## Summary
- add optional `owners` input to the `create_board` platform API tool schema
- pass `owners` through `CreateBoardMutationVariables` and into the `create_board` GraphQL mutation
- update generated GraphQL variable typing used by the tool so the new param is accepted

## Test plan
- [ ] run `npm run codegen` in `packages/agent-toolkit` (full codegen sync)
- [ ] run `npm run build` in `packages/agent-toolkit`
- [ ] smoke: `create_board` with `owners` and confirm request includes `owners`

Made with [Cursor](https://cursor.com)