### PR TITLE
fix(update-doc): accept plain string insert in delta_format schema

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.10.2",
+  "version": "5.10.3",
 
 
   "description": "monday.com agent toolkit",

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.schema.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/update-doc-tool/update-doc-tool.schema.ts
@@ -35,7 +35,12 @@ const ColumnValueInsertSchema = z.object({
 
 export const DeltaOperationSchema = z.object({
   insert: z
-    .union([z.object({ text: z.string() }), MentionInsertSchema, ColumnValueInsertSchema])
+    .union([
+      z.string().transform((s) => ({ text: s })),
+      z.object({ text: z.string() }),
+      MentionInsertSchema,
+      ColumnValueInsertSchema,
+    ])
     .describe(
       'Content to insert. Use {text: "..."} for plain text, {mention: {id, type}} to tag a user/doc/board, or {column_value: {item_id, column_id}} to embed a live column value. The last operation in the array must be {text: "\\n"}.',
     ),

--- a/packages/monday-api-mcp/package.json
+++ b/packages/monday-api-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/monday-api-mcp",
-  "version": "3.1.2",
+  "version": "3.1.3",
   "description": "MCP server for using the monday.com API",
   "mcpName": "com.monday/monday.com",
   "license": "MIT",

--- a/packages/monday-api-mcp/package.json
+++ b/packages/monday-api-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/monday-api-mcp",
-  "version": "3.1.3",
+  "version": "3.1.2",
   "description": "MCP server for using the monday.com API",
   "mcpName": "com.monday/monday.com",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- The `update_doc` tool's `DeltaOperationSchema` only accepted `insert` as an object (`{text: "..."}`) but the LLM naturally generates standard Quill format with plain string inserts (`{"insert": "Hello"}`), causing schema validation to reject valid tool calls before execution
- Added `z.string().transform((s) => ({ text: s }))` as the first union member — plain strings are coerced to the object form automatically; existing object-form inputs are unaffected
- TypeScript, lint, and all 56 existing tests pass with no changes needed

## Monday Item
https://monday.monday.com/boards/3713040192/pulses/11745156520

## Test Plan
- [ ] Existing tests pass: `yarn test --testPathPattern="update-doc-tool"` (56 tests)
- [ ] TypeScript compiles clean: `tsc --noEmit`
- [ ] Verify agent can call `update_doc` with plain string inserts (e.g. `{"insert": "Hello world"}`) without schema validation error

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
