### PR TITLE
fix: list all workspaces by default

### DIFF
--- a/packages/agent-toolkit/README.md
+++ b/packages/agent-toolkit/README.md
@@ -50,7 +50,7 @@ The toolkit includes several pre-built tools for common monday.com operations, o
 
 ### Workspace Operations
 
-- `ListWorkspaceTool` - List workspaces available to the user, prioritizing workspaces where the user is a member
+- `ListWorkspaceTool` - List workspaces available to the user
 
 ### Dynamic API Tools
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts
@@ -43,8 +43,7 @@ describe('ListWorkspaceTool', () => {
         workspaces: null,
       };
 
-      // Both member and all workspaces return null
-      mocks.setResponses([response, response]);
+      mocks.setResponses([response]);
 
       const args: inputType = {};
 
@@ -53,16 +52,11 @@ describe('ListWorkspaceTool', () => {
       const parsed = parseToolResult(result);
       expect(parsed.message).toBe('No workspaces found.');
       expect(parsed.data).toEqual([]);
-      // Two calls: first member (empty), then all (also empty)
-      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(2);
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
 
       const firstCall = mocks.getMockRequest().mock.calls[0];
       expect(firstCall[0]).toContain('query listWorkspaces');
-      expect(firstCall[1]).toMatchObject({ membershipKind: 'member' });
-
-      const secondCall = mocks.getMockRequest().mock.calls[1];
-      expect(secondCall[0]).toContain('query listWorkspaces');
-      expect(secondCall[1]).toMatchObject({ membershipKind: 'all' });
+      expect(firstCall[1]).toMatchObject({ membershipKind: 'all' });
     });
 
     it('should return "No workspaces found." when GraphQL query returns empty array', async () => {
@@ -70,8 +64,7 @@ describe('ListWorkspaceTool', () => {
         workspaces: [],
       };
 
-      // Both member and all workspaces return empty array
-      mocks.setResponses([response, response]);
+      mocks.setResponses([response]);
 
       const args: inputType = {};
 
@@ -80,21 +73,16 @@ describe('ListWorkspaceTool', () => {
       const parsed = parseToolResult(result);
       expect(parsed.message).toBe('No workspaces found.');
       expect(parsed.data).toEqual([]);
-      // Two calls: first member (empty), then all (also empty)
-      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(2);
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
 
       const firstCall = mocks.getMockRequest().mock.calls[0];
       expect(firstCall[0]).toContain('query listWorkspaces');
-      expect(firstCall[1]).toMatchObject({ membershipKind: 'member' });
-
-      const secondCall = mocks.getMockRequest().mock.calls[1];
-      expect(secondCall[0]).toContain('query listWorkspaces');
-      expect(secondCall[1]).toMatchObject({ membershipKind: 'all' });
+      expect(firstCall[1]).toMatchObject({ membershipKind: 'all' });
     });
   });
 
   describe('Successful Flow Without SearchTerm', () => {
-    it('should list workspaces without search term (basic case) using member-only query', async () => {
+    it('should list all accessible workspaces without search term', async () => {
       const response = {
         workspaces: [
           { id: '123', name: 'Marketing Team', description: 'Marketing workspace' },
@@ -116,7 +104,7 @@ describe('ListWorkspaceTool', () => {
       expect(mockCall[1]).toEqual({
         limit: 100,
         page: 1,
-        membershipKind: 'member',
+        membershipKind: 'all',
       });
 
       const parsed = parseToolResult(result);

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.ts
@@ -72,27 +72,29 @@ export class ListWorkspaceTool extends BaseMondayApiTool<typeof listWorkspaceToo
       membershipKind,
     });
 
-    // First, try to get workspaces where the user is a member (more relevant results)
-    const memberRes = await this.mondayApi.request<ListWorkspacesQuery>(
+    const initialMembershipKind = searchTermNormalized ? WorkspaceMembershipKind.Member : WorkspaceMembershipKind.All;
+
+    const initialRes = await this.mondayApi.request<ListWorkspacesQuery>(
       listWorkspaces,
-      createVariables(WorkspaceMembershipKind.Member),
+      createVariables(initialMembershipKind),
     );
-    const memberWorkspaces = filterNullWorkspaces(memberRes);
+    let workspaces = filterNullWorkspaces(initialRes);
 
     const shouldFetchAllWorkspaces =
-      !arrayHasElements(memberWorkspaces) || (searchTermNormalized && !hasMatchingWorkspace(searchTermNormalized, memberWorkspaces));
+      searchTermNormalized &&
+      (!arrayHasElements(workspaces) || !hasMatchingWorkspace(searchTermNormalized, workspaces));
 
-    // Fetch all workspaces only if needed, otherwise use member workspaces
-    let workspaces = memberWorkspaces;
+    // Unfiltered listing uses all workspaces. For search, start with member
+    // workspaces and fall back to all workspaces when member workspaces do not match.
 
     if (shouldFetchAllWorkspaces) {
       const allWorkspacesRes = await this.mondayApi.request<ListWorkspacesQuery>(
         listWorkspaces,
         createVariables(WorkspaceMembershipKind.All),
       );
-      workspaces = filterNullWorkspaces(allWorkspacesRes);
+      const allWorkspaces = filterNullWorkspaces(allWorkspacesRes);
+      workspaces = arrayHasElements(allWorkspaces) ? allWorkspaces : workspaces;
     }
-
 
     if (!arrayHasElements(workspaces)) {
       return {


### PR DESCRIPTION
Fixes #305.

## Summary
- make unfiltered `list_workspaces` request all accessible workspaces instead of member-only workspaces
- keep the existing member-first path for searches, with fallback to all workspaces when member results do not match
- update the toolkit README wording and focused tests for the unfiltered path

## Verification
- `yarn jest src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts --runInBand`
- `npx eslint src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.ts src/core/tools/platform-api-tools/list-workspace-tool/list-workspace-tool.test.ts`
- `yarn workspace @mondaydotcomorg/agent-toolkit build`
- `git diff --check`

The package build completed successfully. It still reports the existing circular-dependency and declaration-bundle warnings, but exits 0.

This was implemented with Codex assistance, with the final diff reviewed before posting.