### PR TITLE
docs: fix monday token env var name

### DIFF
--- a/packages/monday-api-mcp/README.md
+++ b/packages/monday-api-mcp/README.md
@@ -24,13 +24,13 @@ Before running the MCP server, make sure you have:
 npx @mondaydotcomorg/monday-api-mcp@latest -t abcd123
 ```
 
-The monday.com API token can also be provided via the `monday_token` environment variable.
+The monday.com API token can also be provided via the `MONDAY_TOKEN` environment variable.
 
 ### Command Line Arguments
 
 | Argument | Flags | Description | Required | Default |
 |----------|-------|-------------|----------|---------|
-| monday.com API Token | `--token`, `-t` | monday.com API token (can also be provided via `monday_token` environment variable) | Yes | - |
+| monday.com API Token | `--token`, `-t` | monday.com API token (can also be provided via `MONDAY_TOKEN` environment variable) | Yes | - |
 | API Version | `--version`, `-v` | monday.com API version | No | `current` |
 | Read Only Mode | `--read-only`, `-ro` | Enable read-only mode | No | `false` |
 | Mode | `--mode`, `-m` | Set the mode for tool selection: "api" - API tools only, "apps" - (Beta) Monday Apps tools only, "atp" - (Alpha) ATP server mode | No | `api` |
@@ -121,7 +121,7 @@ npx @mondaydotcomorg/monday-api-mcp@latest -t abcd123 -m atp
         "@mondaydotcomorg/monday-api-mcp@latest"
       ],
       "env": {
-        "monday_token": "abcd123"
+        "MONDAY_TOKEN": "abcd123"
       }
     }
   }


### PR DESCRIPTION
## Summary
- update the package README to document `MONDAY_TOKEN` instead of `monday_token`
- align the package-level Cursor example with the root README and the CLI arg parser

## Verification
- `rg -n "monday_token|MONDAY_TOKEN" packages/monday-api-mcp/README.md README.md packages/monday-api-mcp/src/utils/args`
- `git diff --check`

I checked `packages/monday-api-mcp/src/utils/args/args.service.ts`; it builds env var names as `MONDAY_${config.name.toUpperCase()}`, so the `token` arg reads `MONDAY_TOKEN`.

This was implemented with Codex assistance, with the final diff reviewed before posting.