### PR TITLE
Add compact get_board_info response option

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts
@@ -12,6 +12,12 @@ import { NonDeprecatedColumnType } from 'src/utils/types';
 
 export const getBoardInfoToolSchema = {
   boardId: z.number().describe('The id of the board to get information for'),
+  compact: z
+    .boolean()
+    .optional()
+    .describe(
+      'Return a smaller response by omitting verbose column settings and board view settings/filter/sort details',
+    ),
 };
 
 export class GetBoardInfoTool extends BaseMondayApiTool<typeof getBoardInfoToolSchema | undefined> {
@@ -27,7 +33,7 @@ export class GetBoardInfoTool extends BaseMondayApiTool<typeof getBoardInfoToolS
   getDescription(): string {
     return (
       'Get comprehensive board information including metadata, structure, owners, and configuration. ' +
-      'Also returns the board\'s views (e.g. table views, filter views) — each view includes its id, name, type, and a structured filter object. '
+      "Also returns the board's views (e.g. table views, filter views) — each view includes its id, name, type, and a structured filter object. "
     );
   }
 
@@ -53,7 +59,7 @@ export class GetBoardInfoTool extends BaseMondayApiTool<typeof getBoardInfoToolS
     const subItemsBoard = await this.getSubItemsBoardAsync(board);
 
     return {
-      content: formatBoardInfoAsJson(board, subItemsBoard)
+      content: formatBoardInfoAsJson(board, subItemsBoard, { compact: input.compact }),
     };
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts
@@ -1,5 +1,10 @@
 import { formatBoardInfoAsJson, BoardInfoData } from './helpers';
-import { BoardViewAccessLevel, State, BoardKind, WorkspaceKind } from '../../../../monday-graphql/generated/graphql/graphql';
+import {
+  BoardViewAccessLevel,
+  State,
+  BoardKind,
+  WorkspaceKind,
+} from '../../../../monday-graphql/generated/graphql/graphql';
 import { NonDeprecatedColumnType } from 'src/utils/types';
 
 describe('formatBoardInfoAsJson - board structure', () => {
@@ -156,6 +161,51 @@ describe('formatBoardInfoAsJson - board structure', () => {
     expect(result.board.subItemColumns).toHaveLength(1);
     expect(result.board.subItemColumns?.[0]?.id).toBe('sub_col_1');
   });
+
+  it('should omit verbose column fields in compact mode', () => {
+    const mockBoard = {
+      id: '123456789',
+      name: 'Main Board',
+      columns: [
+        {
+          id: 'main_col_1',
+          title: 'Main Task Name',
+          description: 'The name of the main task',
+          type: NonDeprecatedColumnType.Text,
+          settings: { width: 200 },
+          revision: 'abc',
+        },
+      ],
+    } as any;
+
+    const mockSubItemBoard = {
+      columns: [
+        {
+          id: 'sub_col_1',
+          title: 'Sub Task Name',
+          description: 'The name of the sub task',
+          type: NonDeprecatedColumnType.Text,
+          settings: { width: 150 },
+          revision: 'def',
+        },
+      ],
+    } as any;
+
+    const result = formatBoardInfoAsJson(mockBoard, mockSubItemBoard, { compact: true }) as any;
+
+    expect(result.board.columns[0]).toEqual({
+      id: 'main_col_1',
+      title: 'Main Task Name',
+      description: 'The name of the main task',
+      type: NonDeprecatedColumnType.Text,
+    });
+    expect(result.board.subItemColumns[0]).toEqual({
+      id: 'sub_col_1',
+      title: 'Sub Task Name',
+      description: 'The name of the sub task',
+      type: NonDeprecatedColumnType.Text,
+    });
+  });
 });
 
 describe('formatBoardInfoAsJson - views', () => {
@@ -194,7 +244,12 @@ describe('formatBoardInfoAsJson - views', () => {
           settings: {},
           filter: {
             operator: 'AND',
-            groups: [{ operator: 'AND', rules: [{ column_id: 'person', compare_value: ['assigned_to_me'], operator: 'ANY_OF' }] }],
+            groups: [
+              {
+                operator: 'AND',
+                rules: [{ column_id: 'person', compare_value: ['assigned_to_me'], operator: 'ANY_OF' }],
+              },
+            ],
           },
           sort: [],
           access_level: BoardViewAccessLevel.Edit,
@@ -232,7 +287,9 @@ describe('formatBoardInfoAsJson - views', () => {
   it('should include the structured filter object from the view', () => {
     const filter = {
       operator: 'AND',
-      groups: [{ operator: 'AND', rules: [{ column_id: 'person', compare_value: ['assigned_to_me'], operator: 'ANY_OF' }] }],
+      groups: [
+        { operator: 'AND', rules: [{ column_id: 'person', compare_value: ['assigned_to_me'], operator: 'ANY_OF' }] },
+      ],
     };
     const board: BoardInfoData = {
       ...baseBoard,
@@ -285,13 +342,63 @@ describe('formatBoardInfoAsJson - views', () => {
     const board: BoardInfoData = {
       ...baseBoard,
       views: [
-        { id: 'view_1', name: 'View A', type: 'TableBoardView', settings: {}, filter: null, sort: [], access_level: BoardViewAccessLevel.Edit },
-        { id: 'view_2', name: 'View B', type: 'TableBoardView', settings: {}, filter: null, sort: [], access_level: BoardViewAccessLevel.Edit },
+        {
+          id: 'view_1',
+          name: 'View A',
+          type: 'TableBoardView',
+          settings: {},
+          filter: null,
+          sort: [],
+          access_level: BoardViewAccessLevel.Edit,
+        },
+        {
+          id: 'view_2',
+          name: 'View B',
+          type: 'TableBoardView',
+          settings: {},
+          filter: null,
+          sort: [],
+          access_level: BoardViewAccessLevel.Edit,
+        },
       ],
     } as unknown as BoardInfoData;
 
     const result = formatBoardInfoAsJson(board, null) as any;
 
     expect(result.board.views).toHaveLength(2);
+  });
+
+  it('should omit verbose view fields in compact mode', () => {
+    const board: BoardInfoData = {
+      ...baseBoard,
+      views: [
+        {
+          id: 'view_1',
+          name: 'Assigned to Me',
+          type: 'TableBoardView',
+          settings: { visibleColumns: ['name'] },
+          filter: {
+            operator: 'AND',
+            groups: [
+              {
+                operator: 'AND',
+                rules: [{ column_id: 'person', compare_value: ['assigned_to_me'], operator: 'ANY_OF' }],
+              },
+            ],
+          },
+          sort: [{ column_id: 'date', direction: 'asc' }],
+          access_level: BoardViewAccessLevel.Edit,
+        },
+      ],
+    } as unknown as BoardInfoData;
+
+    const result = formatBoardInfoAsJson(board, null, { compact: true }) as any;
+
+    expect(result.board.views[0]).toEqual({
+      id: 'view_1',
+      name: 'Assigned to Me',
+      type: 'TableBoardView',
+      access_level: BoardViewAccessLevel.Edit,
+    });
   });
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/helpers.ts
@@ -4,16 +4,56 @@ export type BoardInfoData = NonNullable<NonNullable<GetBoardInfoQuery['boards']>
 export type BoardInfoJustColumnsData = NonNullable<NonNullable<GetBoardInfoJustColumnsQuery['boards']>[0]>;
 export type ColumnInfo = NonNullable<BoardInfoJustColumnsData['columns']>[0];
 
+interface BoardInfoFormatOptions {
+  compact?: boolean;
+}
+
 export interface BoardInfoResponse {
   board: BoardInfoData & { subItemColumns: ColumnInfo[] | undefined };
 }
 
+const compactColumns = (columns: BoardInfoData['columns'] | BoardInfoJustColumnsData['columns']) =>
+  columns?.map((column) => {
+    if (!column) {
+      return column;
+    }
+
+    const { settings, revision, ...compactColumn } = column;
+    return compactColumn;
+  });
+
+const compactViews = (views: BoardInfoData['views']) =>
+  views?.map((view) => {
+    if (!view) {
+      return view;
+    }
+
+    const { settings, filter, sort, ...compactView } = view;
+    return compactView;
+  });
+
 export const formatBoardInfoAsJson = (
   board: BoardInfoData,
   subItemsBoard: BoardInfoJustColumnsData | null,
-): BoardInfoResponse => ({
-  board: {
-    ...board,
-    subItemColumns: subItemsBoard?.columns ?? undefined,
-  },
-});
+  options: BoardInfoFormatOptions = {},
+): BoardInfoResponse => {
+  const subItemColumns = subItemsBoard?.columns ?? undefined;
+
+  if (!options.compact) {
+    return {
+      board: {
+        ...board,
+        subItemColumns,
+      },
+    };
+  }
+
+  return {
+    board: {
+      ...board,
+      columns: compactColumns(board.columns),
+      views: compactViews(board.views),
+      subItemColumns: compactColumns(subItemColumns),
+    } as BoardInfoResponse['board'],
+  };
+};


### PR DESCRIPTION
Addresses #218.

## Summary
- add an optional `compact` flag to `get_board_info`
- keep the existing full response as the default
- in compact mode, omit verbose column `settings`/`revision` data and board view `settings`/`filter`/`sort` data, including subitem columns

## Verification
- `yarn --cwd packages/agent-toolkit jest src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts --runInBand`
- `./node_modules/.bin/prettier.cmd --check packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.test.ts packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/helpers.ts`
- `git diff --check`

I also ran `yarn --cwd packages/agent-toolkit tsc --noEmit`; it still stops on the existing `src/mcp/toolkit.ts(324)` deep type-instantiation error, with no new `get-board-info` type errors after this change.

Implemented with Codex assistance; I reviewed the patch and kept the behavior opt-in so the default response remains unchanged.
