### PR TITLE
Document GitHub Copilot CLI Node 20 setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,29 @@ To interact with monday.com's API, you'll need an API token:
 }
 ```
 
+#### For GitHub Copilot CLI on macOS
+
+If your MCP client starts the server from a non-interactive shell, make sure it runs with Node 20. The repository's `.nvmrc` pins `v20.18.1`, and the MCP package requires Node 20 or newer.
+
+When using `nvm`, load it before starting the local server:
+
+```json
+{
+  "mcpServers": {
+    "monday-api-mcp": {
+      "command": "bash",
+      "args": [
+        "-lc",
+        "export NVM_DIR=\"$HOME/.nvm\" && . \"$NVM_DIR/nvm.sh\" && nvm use 20 >/dev/null && npx @mondaydotcomorg/monday-api-mcp@latest"
+      ],
+      "env": {
+        "MONDAY_TOKEN": "your_monday_api_token"
+      }
+    }
+  }
+}
+```
+
 #### For Gemini CLI
 
 To get started with [Gemini CLI](https://geminicli.com), you can use the


### PR DESCRIPTION
Helps with #230.

## Summary
- add a GitHub Copilot CLI on macOS local MCP setup example
- show how to load `nvm` and run the local server with Node 20 before invoking `npx`
- keep this scoped to the local setup workaround; it does not change hosted MCP/OAuth behavior

## Verification
- `git diff --check`

Implemented with Codex assistance; I reviewed the docs change and kept it limited to the Node 20 local setup path described in the issue.
