### PR TITLE
feat(agent-toolkit): add update_workflow tool

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-"version": "5.16.0",
+"version": "5.17.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -229,7 +229,6 @@ export * from './get-notetaker-meetings-tool/get-notetaker-meetings-tool';
 export * from './fetch-file-content-tool/fetch-file-content-tool';
 // monday Platform Agents
 export * from './agents-tools';
-// Workflow Builder Tools
 // Workflows
 export * from './workflows-tools';
 // Workflow Builder Tools

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -74,7 +74,7 @@ import { ListAutomationsTool } from './workflows-tools/list-workflows/list-workf
 import { ManageWorkflowsTool } from './workflows-tools/manage-workflows/manage-workflows-tool';
 import { CreateAutomationTool } from './workflows-tools/create-automation/create-automation-tool';
 import { CreateWorkflowBuilderTool } from './workflow-builder-tools/create-workflow/create-workflow-tool';
-import { UpdateWorkflowBuilderTool } from './workflow-builder-tools/update-workflow/update-workflow-tool';
+import { UpdateWorkflowTool } from './workflow-builder-tools/update-workflow/update-workflow-tool';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   DeleteItemTool,
@@ -158,7 +158,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   // Workflow Builder Tools
   CreateWorkflowBuilderTool,
   // Cast: ctor signature (api, apiToken, context?) doesn't match BaseMondayApiToolConstructor.
-  UpdateWorkflowBuilderTool as unknown as BaseMondayApiToolConstructor,
+  UpdateWorkflowTool as unknown as BaseMondayApiToolConstructor,
 ];
 
 export * from './all-monday-api-tool';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -74,6 +74,7 @@ import { ListAutomationsTool } from './workflows-tools/list-workflows/list-workf
 import { ManageWorkflowsTool } from './workflows-tools/manage-workflows/manage-workflows-tool';
 import { CreateAutomationTool } from './workflows-tools/create-automation/create-automation-tool';
 import { CreateWorkflowBuilderTool } from './workflow-builder-tools/create-workflow/create-workflow-tool';
+import { UpdateWorkflowBuilderTool } from './workflow-builder-tools/update-workflow/update-workflow-tool';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   DeleteItemTool,
@@ -156,6 +157,8 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   CreateAutomationTool as unknown as BaseMondayApiToolConstructor,
   // Workflow Builder Tools
   CreateWorkflowBuilderTool,
+  // Cast: ctor signature (api, apiToken, context?) doesn't match BaseMondayApiToolConstructor.
+  UpdateWorkflowBuilderTool as unknown as BaseMondayApiToolConstructor,
 ];
 
 export * from './all-monday-api-tool';
@@ -226,10 +229,12 @@ export * from './get-notetaker-meetings-tool/get-notetaker-meetings-tool';
 export * from './fetch-file-content-tool/fetch-file-content-tool';
 // monday Platform Agents
 export * from './agents-tools';
+// Workflow Builder Tools
 // Workflows
 export * from './workflows-tools';
 // Workflow Builder Tools
 export * from './workflow-builder-tools/create-workflow/create-workflow-tool';
+export * from './workflow-builder-tools/update-workflow/update-workflow-tool';
 // Dashboard Tools
 export * from './dashboard-tools';
 // Monday Dev Tools

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/constants.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/constants.ts
@@ -1,0 +1,1 @@
+export const WORKFLOW_BUILDER_AGENT_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-builder';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/index.ts
@@ -1,1 +1,0 @@
-export * from './update-workflow/update-workflow-tool';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/index.ts
@@ -1,0 +1,1 @@
+export * from './update-workflow/update-workflow-tool';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.test.ts
@@ -1,7 +1,6 @@
 import { MondayAgentToolkit } from 'src/mcp/toolkit';
 import { callToolByNameRawAsync, createMockApiClient, parseToolResult } from '../../test-utils/mock-api-client';
-
-const WORKFLOW_BUILDER_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-builder';
+import { WORKFLOW_BUILDER_AGENT_URL } from '../constants';
 
 function mockFetchResponse({
   ok = true,
@@ -49,7 +48,7 @@ describe('UpdateWorkflowBuilderTool', () => {
 
     expect(fetchSpy).toHaveBeenCalledTimes(1);
     const [url, init] = fetchSpy.mock.calls[0];
-    expect(url).toBe(WORKFLOW_BUILDER_URL);
+    expect(url).toBe(WORKFLOW_BUILDER_AGENT_URL);
     expect(init.method).toBe('POST');
     expect(init.headers).toMatchObject({
       Authorization: 'test-token',

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.test.ts
@@ -1,0 +1,151 @@
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameRawAsync, createMockApiClient, parseToolResult } from '../../test-utils/mock-api-client';
+
+const WORKFLOW_BUILDER_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-builder';
+
+function mockFetchResponse({
+  ok = true,
+  status = 200,
+  body = {},
+}: {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+} = {}): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('UpdateWorkflowBuilderTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('posts to the workflow-builder agent URL with correct body and Authorization header', async () => {
+    fetchSpy.mockResolvedValue(
+      mockFetchResponse({
+        body: { workflowObjectId: 5002722216, workflowDraftId: 43023, result: 'Added an email step' },
+      }),
+    );
+
+    await callToolByNameRawAsync('update_workflow_builder', {
+      workflowObjectId: 5002722216,
+      workflowDraftId: 43023,
+      prompt: 'add a step that sends an email when an item is created',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(WORKFLOW_BUILDER_URL);
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'test-token',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      workflowObjectId: 5002722216,
+      workflowDraftId: 43023,
+      prompt: 'add a step that sends an email when an item is created',
+    });
+  });
+
+  it('passes through the agent result on success', async () => {
+    fetchSpy.mockResolvedValue(
+      mockFetchResponse({
+        body: {
+          workflowObjectId: 5002722216,
+          workflowDraftId: 43023,
+          result: 'Added an email notification step after the trigger',
+        },
+      }),
+    );
+
+    const result = await callToolByNameRawAsync('update_workflow_builder', {
+      workflowObjectId: 5002722216,
+      workflowDraftId: 43023,
+      prompt: 'add an email step',
+    });
+    const parsed = parseToolResult(result);
+
+    expect(parsed.workflowObjectId).toBe(5002722216);
+    expect(parsed.workflowDraftId).toBe(43023);
+    expect(parsed.result).toBe('Added an email notification step after the trigger');
+  });
+
+  it('rejects missing workflowObjectId before making any HTTP call', async () => {
+    const result = await callToolByNameRawAsync('update_workflow_builder', {
+      workflowDraftId: 43023,
+      prompt: 'add a step',
+    });
+
+    expect(result.content[0].text).toContain('workflowObjectId');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects missing workflowDraftId before making any HTTP call', async () => {
+    const result = await callToolByNameRawAsync('update_workflow_builder', {
+      workflowObjectId: 5002722216,
+      prompt: 'add a step',
+    });
+
+    expect(result.content[0].text).toContain('workflowDraftId');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects empty prompt before making any HTTP call', async () => {
+    const result = await callToolByNameRawAsync('update_workflow_builder', {
+      workflowObjectId: 5002722216,
+      workflowDraftId: 43023,
+      prompt: '   ',
+    });
+
+    expect(result.content[0].text).toContain('prompt must be a non-empty string');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the error envelope on 4xx', async () => {
+    fetchSpy.mockResolvedValue(
+      mockFetchResponse({
+        ok: false,
+        status: 400,
+        body: { error: 'Prompt exceeds maximum length of 2000 characters', code: 'PROMPT_TOO_LONG' },
+      }),
+    );
+
+    const result = await callToolByNameRawAsync('update_workflow_builder', {
+      workflowObjectId: 5002722216,
+      workflowDraftId: 43023,
+      prompt: 'add a step',
+    });
+
+    expect(result.content[0].text).toContain('Failed to update workflow');
+    expect(result.content[0].text).toContain('HTTP 400');
+    expect(result.content[0].text).toContain('PROMPT_TOO_LONG');
+  });
+
+  it('wraps network errors with operation context', async () => {
+    fetchSpy.mockRejectedValue(new Error('network failure'));
+
+    const result = await callToolByNameRawAsync('update_workflow_builder', {
+      workflowObjectId: 5002722216,
+      workflowDraftId: 43023,
+      prompt: 'add a step',
+    });
+
+    expect(result.content[0].text).toContain('Failed to update workflow');
+    expect(result.content[0].text).toContain('network failure');
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.test.ts
@@ -19,7 +19,7 @@ function mockFetchResponse({
   } as unknown as Response;
 }
 
-describe('UpdateWorkflowBuilderTool', () => {
+describe('UpdateWorkflowTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
   let fetchSpy: jest.SpyInstance;
 
@@ -40,7 +40,7 @@ describe('UpdateWorkflowBuilderTool', () => {
       }),
     );
 
-    await callToolByNameRawAsync('update_workflow_builder', {
+    await callToolByNameRawAsync('update_workflow', {
       workflowObjectId: 5002722216,
       workflowDraftId: 43023,
       prompt: 'add a step that sends an email when an item is created',
@@ -72,7 +72,7 @@ describe('UpdateWorkflowBuilderTool', () => {
       }),
     );
 
-    const result = await callToolByNameRawAsync('update_workflow_builder', {
+    const result = await callToolByNameRawAsync('update_workflow', {
       workflowObjectId: 5002722216,
       workflowDraftId: 43023,
       prompt: 'add an email step',
@@ -85,7 +85,7 @@ describe('UpdateWorkflowBuilderTool', () => {
   });
 
   it('rejects missing workflowObjectId before making any HTTP call', async () => {
-    const result = await callToolByNameRawAsync('update_workflow_builder', {
+    const result = await callToolByNameRawAsync('update_workflow', {
       workflowDraftId: 43023,
       prompt: 'add a step',
     });
@@ -95,7 +95,7 @@ describe('UpdateWorkflowBuilderTool', () => {
   });
 
   it('rejects missing workflowDraftId before making any HTTP call', async () => {
-    const result = await callToolByNameRawAsync('update_workflow_builder', {
+    const result = await callToolByNameRawAsync('update_workflow', {
       workflowObjectId: 5002722216,
       prompt: 'add a step',
     });
@@ -105,7 +105,7 @@ describe('UpdateWorkflowBuilderTool', () => {
   });
 
   it('rejects empty prompt before making any HTTP call', async () => {
-    const result = await callToolByNameRawAsync('update_workflow_builder', {
+    const result = await callToolByNameRawAsync('update_workflow', {
       workflowObjectId: 5002722216,
       workflowDraftId: 43023,
       prompt: '   ',
@@ -124,7 +124,7 @@ describe('UpdateWorkflowBuilderTool', () => {
       }),
     );
 
-    const result = await callToolByNameRawAsync('update_workflow_builder', {
+    const result = await callToolByNameRawAsync('update_workflow', {
       workflowObjectId: 5002722216,
       workflowDraftId: 43023,
       prompt: 'add a step',
@@ -138,7 +138,7 @@ describe('UpdateWorkflowBuilderTool', () => {
   it('wraps network errors with operation context', async () => {
     fetchSpy.mockRejectedValue(new Error('network failure'));
 
-    const result = await callToolByNameRawAsync('update_workflow_builder', {
+    const result = await callToolByNameRawAsync('update_workflow', {
       workflowObjectId: 5002722216,
       workflowDraftId: 43023,
       prompt: 'add a step',

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -24,7 +24,7 @@ export const updateWorkflowToolSchema = {
     .min(1, 'prompt must be a non-empty string')
     .max(2000, 'prompt must not exceed 2000 characters')
     .describe(
-      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "Add a trigger that fires when an item is created on Amit\'s Board (5001393610)"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
+      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "Add a trigger that fires when an item is created on board 1234567890"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
     ),
 };
 
@@ -55,7 +55,7 @@ Use this after create_workflow to build out the workflow step by step. You can c
 
 Parameters:
 - workflowObjectId and workflowDraftId: both returned by create_workflow — they identify which draft to update.
-- prompt: describe what you want to change in plain English (e.g. "Add a trigger that fires when an item is created on Amit's Board (5001393610)"). Maximum 2000 characters.
+- prompt: describe what you want to change in plain English (e.g. "Add a trigger that fires when an item is created on board 1234567890"). Maximum 2000 characters.
 
 Returns:
 - workflowObjectId: the workflow object ID (unchanged)

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -1,0 +1,83 @@
+import { ApiClient } from '@mondaydotcomorg/api';
+import { z } from 'zod';
+import { ToolInputType, ToolOutputType, ToolType } from '../../../../tool';
+import { BaseMondayApiTool, MondayApiToolContext, createMondayApiAnnotations } from '../../base-monday-api-tool';
+import { rethrowWithContext } from '../../../../../utils';
+
+const WORKFLOW_BUILDER_AGENT_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-builder';
+const REQUEST_TIMEOUT_MS = 180_000;
+
+export const updateWorkflowBuilderToolSchema = {
+  workflowObjectId: z.number().describe('The stable workflow entity ID (workflow_object_id returned by create_workflow_builder).'),
+  workflowDraftId: z.number().describe('The draft workflow ID to update (workflow_draft_id returned by create_workflow_builder).'),
+  prompt: z
+    .string()
+    .trim()
+    .min(1, 'prompt must be a non-empty string')
+    .describe('Natural-language description of the changes to make to the workflow (e.g. "add a step that sends an email when an item is created").'),
+};
+
+export class UpdateWorkflowBuilderTool extends BaseMondayApiTool<typeof updateWorkflowBuilderToolSchema> {
+  name = 'update_workflow_builder';
+  type = ToolType.WRITE;
+  annotations = createMondayApiAnnotations({
+    title: 'Update Workflow Builder',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+  });
+
+  constructor(
+    api: ApiClient,
+    private readonly apiToken: string,
+    context?: MondayApiToolContext,
+  ) {
+    super(api, context);
+  }
+
+  getDescription(): string {
+    return `Updates an existing Workflow Builder workflow from a natural-language description.
+
+Use when the user wants to modify a workflow — add steps, remove steps, change triggers or conditions, etc. Requires the workflowObjectId and workflowDraftId from a previous create_workflow_builder call (or from list_workflows).
+
+Returns:
+- workflowObjectId: the workflow entity ID
+- workflowDraftId: the updated draft ID
+- result: agent response describing the changes made
+`;
+  }
+
+  getInputSchema() {
+    return updateWorkflowBuilderToolSchema;
+  }
+
+  protected async executeInternal(
+    input: ToolInputType<typeof updateWorkflowBuilderToolSchema>,
+  ): Promise<ToolOutputType<never>> {
+    try {
+      const response = await fetch(WORKFLOW_BUILDER_AGENT_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: this.apiToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          workflowObjectId: input.workflowObjectId,
+          workflowDraftId: input.workflowDraftId,
+          prompt: input.prompt,
+        }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`workflow-builder responded with HTTP ${response.status}${body ? `: ${body}` : ''}`);
+      }
+
+      const body = (await response.json()) as Record<string, unknown>;
+      return { content: body };
+    } catch (error) {
+      rethrowWithContext(error, 'update workflow');
+    }
+  }
+}

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -3,18 +3,29 @@ import { z } from 'zod';
 import { ToolInputType, ToolOutputType, ToolType } from '../../../../tool';
 import { BaseMondayApiTool, MondayApiToolContext, createMondayApiAnnotations } from '../../base-monday-api-tool';
 import { rethrowWithContext } from '../../../../../utils';
+import { WORKFLOW_BUILDER_AGENT_URL } from '../constants';
 
-const WORKFLOW_BUILDER_AGENT_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-builder';
 const REQUEST_TIMEOUT_MS = 180_000;
 
 export const updateWorkflowBuilderToolSchema = {
-  workflowObjectId: z.number().describe('The stable workflow entity ID (workflow_object_id returned by create_workflow_builder).'),
-  workflowDraftId: z.number().describe('The draft workflow ID to update (workflow_draft_id returned by create_workflow_builder).'),
+  workflowObjectId: z
+    .number()
+    .describe(
+      'The stable workflow entity ID returned by create_workflow_builder. Identifies the workflow across all its drafts and published versions.',
+    ),
+  workflowDraftId: z
+    .number()
+    .describe(
+      'The draft version ID returned by create_workflow_builder. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update.',
+    ),
   prompt: z
     .string()
     .trim()
     .min(1, 'prompt must be a non-empty string')
-    .describe('Natural-language description of the changes to make to the workflow (e.g. "add a step that sends an email when an item is created").'),
+    .max(2000, 'prompt must not exceed 2000 characters')
+    .describe(
+      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "add a step that sends an email when an item is created"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
+    ),
 };
 
 export class UpdateWorkflowBuilderTool extends BaseMondayApiTool<typeof updateWorkflowBuilderToolSchema> {
@@ -36,14 +47,22 @@ export class UpdateWorkflowBuilderTool extends BaseMondayApiTool<typeof updateWo
   }
 
   getDescription(): string {
-    return `Updates an existing Workflow Builder workflow from a natural-language description.
+    return `Updates an existing Workflow Builder workflow draft using an AI agent.
 
-Use when the user wants to modify a workflow — add steps, remove steps, change triggers or conditions, etc. Requires the workflowObjectId and workflowDraftId from a previous create_workflow_builder call (or from list_workflows).
+The agent interprets the prompt and applies structural changes to the workflow — creating, updating, or deleting steps. Pass clear, descriptive instructions and the agent will decide which operations to perform, then return a summary of what it did.
+
+Use this after create_workflow_builder to build out the workflow step by step. You can call it multiple times on the same draft to iteratively refine the workflow.
+
+Parameters:
+- workflowObjectId and workflowDraftId: both returned by create_workflow_builder — they identify which draft to update.
+- prompt: describe what you want to change in plain English. Maximum 2000 characters.
 
 Returns:
-- workflowObjectId: the workflow entity ID
-- workflowDraftId: the updated draft ID
+- workflowObjectId: the workflow entity ID (unchanged)
+- workflowDraftId: the draft version ID (unchanged)
 - result: agent response describing the changes made
+
+Note: the workflow runs only after it is published to live version.
 `;
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -24,7 +24,7 @@ export const updateWorkflowToolSchema = {
     .min(1, 'prompt must be a non-empty string')
     .max(2000, 'prompt must not exceed 2000 characters')
     .describe(
-      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "add a step that sends an email when an item is created"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
+      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "Add a trigger that fires when an item is created on Amit\'s Board (5001393610)"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
     ),
 };
 
@@ -55,7 +55,7 @@ Use this after create_workflow to build out the workflow step by step. You can c
 
 Parameters:
 - workflowObjectId and workflowDraftId: both returned by create_workflow — they identify which draft to update.
-- prompt: describe what you want to change in plain English. Maximum 2000 characters.
+- prompt: describe what you want to change in plain English (e.g. "Add a trigger that fires when an item is created on Amit's Board (5001393610)"). Maximum 2000 characters.
 
 Returns:
 - workflowObjectId: the workflow object ID (unchanged)

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -16,7 +16,7 @@ export const updateWorkflowToolSchema = {
   workflowDraftId: z
     .number()
     .describe(
-      'The draft version ID returned by create_workflow. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update. A new draft ID is issued after each publish.',
+      'The draft version ID returned by create_workflow. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update. A new version ID is issued after each publish.',
     ),
   prompt: z
     .string()

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -11,12 +11,12 @@ export const updateWorkflowToolSchema = {
   workflowObjectId: z
     .number()
     .describe(
-      'The workflow object ID returned by create_workflow. Identifies the workflow across all its drafts and published versions.',
+      'The workflow object ID returned by create_workflow. Identifies the workflow across all its drafts and published versions. Does not change across publishes.',
     ),
   workflowDraftId: z
     .number()
     .describe(
-      'The draft version ID returned by create_workflow. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update.',
+      'The draft version ID returned by create_workflow. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update. A new draft ID is issued after each publish.',
     ),
   prompt: z
     .string()

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -58,7 +58,7 @@ Parameters:
 - prompt: describe what you want to change in plain English. Maximum 2000 characters.
 
 Returns:
-- workflowObjectId: the workflow entity ID (unchanged)
+- workflowObjectId: the workflow object ID (unchanged)
 - workflowDraftId: the draft version ID (unchanged)
 - result: agent response describing the changes made
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -24,7 +24,7 @@ export const updateWorkflowToolSchema = {
     .min(1, 'prompt must be a non-empty string')
     .max(2000, 'prompt must not exceed 2000 characters')
     .describe(
-      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "Add a trigger that fires when an item is created on board 1234567890"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
+      'Natural-language description of the changes to make. Describe what steps to add, remove, or modify in plain English (e.g. "Add a trigger that fires when an item is created on the Marketing board"). The agent interprets this and applies the right structural changes. Maximum 2000 characters.',
     ),
 };
 
@@ -55,7 +55,7 @@ Use this after create_workflow to build out the workflow step by step. You can c
 
 Parameters:
 - workflowObjectId and workflowDraftId: both returned by create_workflow — they identify which draft to update.
-- prompt: describe what you want to change in plain English (e.g. "Add a trigger that fires when an item is created on board 1234567890"). Maximum 2000 characters.
+- prompt: describe what you want to change in plain English (e.g. "Add a trigger that fires when an item is created on the Marketing board"). Maximum 2000 characters.
 
 Returns:
 - workflowObjectId: the workflow object ID (unchanged)

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -11,7 +11,7 @@ export const updateWorkflowBuilderToolSchema = {
   workflowObjectId: z
     .number()
     .describe(
-      'The stable workflow entity ID returned by create_workflow_builder. Identifies the workflow across all its drafts and published versions.',
+      'The workflow object ID returned by create_workflow_builder. Identifies the workflow across all its drafts and published versions.',
     ),
   workflowDraftId: z
     .number()

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -16,7 +16,7 @@ export const updateWorkflowToolSchema = {
   workflowDraftId: z
     .number()
     .describe(
-      'The draft version ID returned by create_workflow. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update. A new version ID is issued after each publish.',
+      'The draft version ID to update. Use the workflowDraftId from the previous create_workflow or update_workflow response — the agent may return a new draft ID, so always read it from the latest response rather than reusing an earlier value.',
     ),
   prompt: z
     .string()

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -7,16 +7,16 @@ import { WORKFLOW_BUILDER_AGENT_URL } from '../constants';
 
 const REQUEST_TIMEOUT_MS = 180_000;
 
-export const updateWorkflowBuilderToolSchema = {
+export const updateWorkflowToolSchema = {
   workflowObjectId: z
     .number()
     .describe(
-      'The workflow object ID returned by create_workflow_builder. Identifies the workflow across all its drafts and published versions.',
+      'The workflow object ID returned by create_workflow. Identifies the workflow across all its drafts and published versions.',
     ),
   workflowDraftId: z
     .number()
     .describe(
-      'The draft version ID returned by create_workflow_builder. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update.',
+      'The draft version ID returned by create_workflow. The agent applies changes to this specific draft. Both workflowObjectId and workflowDraftId are required — together they identify the exact draft to update.',
     ),
   prompt: z
     .string()
@@ -28,11 +28,11 @@ export const updateWorkflowBuilderToolSchema = {
     ),
 };
 
-export class UpdateWorkflowBuilderTool extends BaseMondayApiTool<typeof updateWorkflowBuilderToolSchema> {
-  name = 'update_workflow_builder';
+export class UpdateWorkflowTool extends BaseMondayApiTool<typeof updateWorkflowToolSchema> {
+  name = 'update_workflow';
   type = ToolType.WRITE;
   annotations = createMondayApiAnnotations({
-    title: 'Update Workflow Builder',
+    title: 'Update Workflow',
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: false,
@@ -47,14 +47,14 @@ export class UpdateWorkflowBuilderTool extends BaseMondayApiTool<typeof updateWo
   }
 
   getDescription(): string {
-    return `Updates an existing Workflow Builder workflow draft using an AI agent.
+    return `Updates an existing workflow draft using an AI agent.
 
 The agent interprets the prompt and applies structural changes to the workflow — creating, updating, or deleting steps. Pass clear, descriptive instructions and the agent will decide which operations to perform, then return a summary of what it did.
 
-Use this after create_workflow_builder to build out the workflow step by step. You can call it multiple times on the same draft to iteratively refine the workflow.
+Use this after create_workflow to build out the workflow step by step. You can call it multiple times on the same draft to iteratively refine the workflow.
 
 Parameters:
-- workflowObjectId and workflowDraftId: both returned by create_workflow_builder — they identify which draft to update.
+- workflowObjectId and workflowDraftId: both returned by create_workflow — they identify which draft to update.
 - prompt: describe what you want to change in plain English. Maximum 2000 characters.
 
 Returns:
@@ -67,11 +67,11 @@ Note: the workflow runs only after it is published to live version.
   }
 
   getInputSchema() {
-    return updateWorkflowBuilderToolSchema;
+    return updateWorkflowToolSchema;
   }
 
   protected async executeInternal(
-    input: ToolInputType<typeof updateWorkflowBuilderToolSchema>,
+    input: ToolInputType<typeof updateWorkflowToolSchema>,
   ): Promise<ToolOutputType<never>> {
     try {
       const response = await fetch(WORKFLOW_BUILDER_AGENT_URL, {


### PR DESCRIPTION
## Summary

- Adds `update_workflow` MCP tool that updates an existing monday.com workflow draft using an AI agent
- The tool calls the platform-agent proxy (`/platform-ai-gateway/agents/workflow-builder`) which invokes the workflow-builder microservice update API
- Extracts `WORKFLOW_BUILDER_AGENT_URL` to a shared constants file (`workflow-builder-tools/constants.ts`)
- 180s timeout for the agent call
- Complements `create_workflow` — use create to scaffold a new workflow, then call update iteratively to build it out

## Notes

- Uses `fetch()` directly with `Authorization` header (same pattern as `create_automation`)
- Registered with `as unknown as BaseMondayApiToolConstructor` cast (non-standard ctor signature)
- Both `workflowObjectId` and `workflowDraftId` are required — returned by `create_workflow`
- Prompt capped at 2000 characters (enforced by Zod + the downstream API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)