### PR TITLE
feat(agent-toolkit): rename list_workflows to list_automations

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.13.0",
+  "version": "5.14.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -70,7 +70,7 @@ import { FetchFileContentTool } from './fetch-file-content-tool/fetch-file-conte
 import { GetAgentTool } from './agents-tools/get-agent/get-agent-tool';
 import { CreateAgentTool } from './agents-tools/create-agent/create-agent-tool';
 import { DeleteAgentTool } from './agents-tools/delete-agent/delete-agent-tool';
-import { ListWorkflowsTool } from './workflows-tools/list-workflows/list-workflows-tool';
+import { ListAutomationsTool } from './workflows-tools/list-workflows/list-workflows-tool';
 import { ManageWorkflowsTool } from './workflows-tools/manage-workflows/manage-workflows-tool';
 import { CreateAutomationTool } from './workflows-tools/create-automation/create-automation-tool';
 
@@ -149,7 +149,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   CreateAgentTool,
   DeleteAgentTool,
   // Workflows (subgraph still on dev API version)
-  ListWorkflowsTool,
+  ListAutomationsTool,
   ManageWorkflowsTool,
   // Cast: ctor signature (api, apiToken, context?) doesn't match BaseMondayApiToolConstructor.
   CreateAutomationTool as unknown as BaseMondayApiToolConstructor,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.test.ts
@@ -1,7 +1,7 @@
 import { MondayAgentToolkit } from 'src/mcp/toolkit';
 import { callToolByNameRawAsync, createMockApiClient, parseToolResult } from '../../test-utils/mock-api-client';
 
-describe('ListWorkflowsTool', () => {
+describe('ListAutomationsTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
 
   beforeEach(() => {
@@ -44,7 +44,7 @@ describe('ListWorkflowsTool', () => {
   it('should return live workflows for the board', async () => {
     mocks.setResponseOnce({ board_automations: { cursor: null, items: [mockBoardAutomation] } });
 
-    const result = await callToolByNameRawAsync('list_workflows', { boardId: '1234567890' });
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
     const parsed = parseToolResult(result);
 
     expect(parsed.workflows).toEqual([expectedWorkflow]);
@@ -55,7 +55,7 @@ describe('ListWorkflowsTool', () => {
   it('should query board_automations with board_ids', async () => {
     mocks.setResponseOnce({ board_automations: { cursor: null, items: [] } });
 
-    await callToolByNameRawAsync('list_workflows', { boardId: '1234567890' });
+    await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.stringContaining('board_automations'),
@@ -68,7 +68,7 @@ describe('ListWorkflowsTool', () => {
   it('should return pagination cursor from board_automations', async () => {
     mocks.setResponseOnce({ board_automations: { cursor: 'next-page', items: [mockBoardAutomation] } });
 
-    const result = await callToolByNameRawAsync('list_workflows', { boardId: '1234567890' });
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
     const parsed = parseToolResult(result);
 
     expect(parsed.pagination).toEqual({ nextCursor: 'next-page', hasMore: true });
@@ -77,7 +77,7 @@ describe('ListWorkflowsTool', () => {
   it('should pass cursor and limit when provided', async () => {
     mocks.setResponseOnce({ board_automations: { cursor: null, items: [] } });
 
-    await callToolByNameRawAsync('list_workflows', { boardId: '1234567890', cursor: '50', limit: 50 });
+    await callToolByNameRawAsync('list_automations', { boardId: '1234567890', cursor: '50', limit: 50 });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.stringContaining('board_automations'),
@@ -89,7 +89,7 @@ describe('ListWorkflowsTool', () => {
   it('should default workflows to an empty array when board_automations items are null', async () => {
     mocks.setResponseOnce({ board_automations: { cursor: null, items: null } });
 
-    const result = await callToolByNameRawAsync('list_workflows', { boardId: '1234567890' });
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
     const parsed = parseToolResult(result);
 
     expect(parsed.workflows).toEqual([]);
@@ -99,13 +99,13 @@ describe('ListWorkflowsTool', () => {
   it('should propagate GraphQL errors with operation context', async () => {
     mocks.setError('Not authorized');
 
-    const result = await callToolByNameRawAsync('list_workflows', { boardId: '1234567890' });
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
 
     expect(result.content[0].text).toContain('Failed to list live workflows');
   });
 
   it('should reject whitespace-only boardId', async () => {
-    const result = await callToolByNameRawAsync('list_workflows', { boardId: '   ' });
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '   ' });
 
     expect(result.content[0].text).toContain('boardId must be a non-empty string');
   });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.ts
@@ -35,39 +35,37 @@ function mapBoardAutomationToWorkflow(automation: BoardAutomation): WorkflowOutp
   };
 }
 
-export const listWorkflowsToolSchema = {
+export const listAutomationsToolSchema = {
   boardId: z.string().trim().min(1, 'boardId must be a non-empty string').describe('The numeric board ID as a string.'),
-  limit: z.number().int().min(1).max(100).optional().describe('Maximum number of workflows to return. Default: 100.'),
+  limit: z.number().int().min(1).max(100).optional().describe('Maximum number of automations to return. Default: 100.'),
   cursor: z
     .string()
     .optional()
-    .describe('Pagination cursor from a previous response. Pass to retrieve the next page of workflows.'),
+    .describe('Pagination cursor from a previous response. Pass to retrieve the next page of automations.'),
 };
 
-export class ListWorkflowsTool extends BaseMondayApiTool<typeof listWorkflowsToolSchema> {
-  name = 'list_workflows';
+export class ListAutomationsTool extends BaseMondayApiTool<typeof listAutomationsToolSchema> {
+  name = 'list_automations';
   type = ToolType.READ;
   annotations = createMondayApiAnnotations({
-    title: 'List Live Workflows',
+    title: 'List Board Automations',
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
   });
 
   getDescription(): string {
-    return `List all automations (workflows) on a monday.com board, including their ids, titles, active state, and configuration.
+    return `List all automations on a specific monday.com board, including their ids, titles, active state, and configuration.
 
-When NOT to use: Do not call this tool to get general board information unrelated to workflows.
-
-Terminology: "workflows" and "automations" are the same thing.`;
+When NOT to use: Do not call this tool to get general board information unrelated to automations.`;
   }
 
   getInputSchema() {
-    return listWorkflowsToolSchema;
+    return listAutomationsToolSchema;
   }
 
   protected async executeInternal(
-    input: ToolInputType<typeof listWorkflowsToolSchema>,
+    input: ToolInputType<typeof listAutomationsToolSchema>,
   ): Promise<ToolOutputType<never>> {
     try {
       const variables: BoardAutomationsQueryVariables = {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/manage-workflows/manage-workflows-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/manage-workflows/manage-workflows-tool.ts
@@ -29,7 +29,7 @@ export const manageWorkflowsToolSchema = {
     .string()
     .trim()
     .min(1, 'workflowId must be a non-empty string')
-    .describe('The workflow ID to operate on. Obtain from list_workflows.'),
+    .describe('The workflow ID to operate on. Obtain from list_automations.'),
 };
 
 interface ActivateWorkflowInput {
@@ -62,7 +62,7 @@ export class ManageWorkflowsTool extends BaseMondayApiTool<typeof manageWorkflow
   getDescription(): string {
     return `Activate, deactivate, or delete an existing monday.com automation/workflow.
 
-Requires a workflow id. When the user refers to a workflow by name, always call list_workflows first to resolve the id — never guess or infer ids.
+Requires a workflow id. When the user refers to an automation by name, always call list_automations first to resolve the id — never guess or infer ids.
 
 Actions:
 - activate: enables a paused workflow so it starts responding to its trigger.


### PR DESCRIPTION
## Summary
- Renamed tool `list_workflows` → `list_automations` to align with board-scoped automations terminology
- Updated class/schema names, descriptions, and annotation title
- Updated `manage_workflows` tool references to point to `list_automations`
- Bumped package version to 5.14.0

## Test plan
- [x] Existing unit tests updated and passing (7/7)
- [ ] Verify downstream consumers handle the tool name change

## Item
https://monday.monday.com/boards/18399225694/views/257773341/pulses/12103094527

🤖 Generated with [Claude Code](https://claude.com/claude-code)