### PR TITLE
feat(agent-toolkit): rename create_workflow_builder to create_workflow, bump to 5.16.0

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-"version": "5.15.1",
+"version": "5.16.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/create-workflow/create-workflow-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/create-workflow/create-workflow-tool.test.ts
@@ -20,7 +20,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should return workflowObjectId and workflowDraftId on success', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    const result = await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42' });
+    const result = await callToolByNameRawAsync('create_workflow', { workspaceId: '42' });
     const parsed = parseToolResult(result);
 
     expect(parsed.workflowObjectId).toBe('999');
@@ -31,7 +31,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should call the mutation with workspace_id and versionOverride dev', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.stringContaining('createWorkflow'),
@@ -43,7 +43,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should pass title when provided', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42', title: 'My Workflow' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42', title: 'My Workflow' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -55,7 +55,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should pass privacy_kind when provided', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42', privacyKind: 'PRIVATE' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42', privacyKind: 'PRIVATE' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -67,7 +67,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should accept SHAREABLE as a valid privacyKind', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42', privacyKind: 'SHAREABLE' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42', privacyKind: 'SHAREABLE' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -79,7 +79,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should pass description when provided', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42', description: 'My description' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42', description: 'My description' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -91,7 +91,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should pass folder_id when provided', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42', folderId: '77' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42', folderId: '77' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -103,7 +103,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should pass owner_ids when provided', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42', ownerIds: ['1', '2'] });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42', ownerIds: ['1', '2'] });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -115,7 +115,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should not include optional fields when not provided', async () => {
     mocks.setResponseOnce(mockResponse);
 
-    await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42' });
+    await callToolByNameRawAsync('create_workflow', { workspaceId: '42' });
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.anything(),
@@ -125,7 +125,7 @@ describe('CreateWorkflowBuilderTool', () => {
   });
 
   it('should reject invalid privacyKind values', async () => {
-    const result = await callToolByNameRawAsync('create_workflow_builder', {
+    const result = await callToolByNameRawAsync('create_workflow', {
       workspaceId: '42',
       privacyKind: 'private',
     });
@@ -134,7 +134,7 @@ describe('CreateWorkflowBuilderTool', () => {
   });
 
   it('should reject whitespace-only workspaceId', async () => {
-    const result = await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '   ' });
+    const result = await callToolByNameRawAsync('create_workflow', { workspaceId: '   ' });
 
     expect(result.content[0].text).toContain('workspaceId must be a non-empty string');
   });
@@ -142,7 +142,7 @@ describe('CreateWorkflowBuilderTool', () => {
   it('should propagate GraphQL errors with operation context', async () => {
     mocks.setError('Not authorized');
 
-    const result = await callToolByNameRawAsync('create_workflow_builder', { workspaceId: '42' });
+    const result = await callToolByNameRawAsync('create_workflow', { workspaceId: '42' });
 
     expect(result.content[0].text).toContain('Failed to create Workflow Builder workflow');
   });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/create-workflow/create-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/create-workflow/create-workflow-tool.ts
@@ -36,16 +36,16 @@ export class CreateWorkflowBuilderTool extends BaseMondayApiTool<typeof createWo
   });
 
   getDescription(): string {
-    return `Creates a new empty Workflow Builder workflow in a monday.com workspace.
+    return `Creates a new empty workflow in a monday.com workspace.
 
-Use this when the user wants to build a new standalone workflow from scratch. Workflow Builder workflows are cross-board, workspace-level automations — distinct from board automations (use create_automation for those). You only need a workspaceId to get started — all other fields are optional.
+Use this when the user wants to build a new standalone workflow from scratch. Workflows are cross-board, workspace-level — distinct from automations (use create_automation for those). You only need a workspaceId to get started — all other fields are optional.
 
 Returns:
 - workflowObjectId: the workflow object ID
 - workflowDraftId: the current draft version ID — workflows start as drafts and must be published before they run
 
 Terminology:
-- Workflow Builder vs. board automations: Workflow Builder workflows are standalone objects scoped to a workspace. Board automations (create_automation) are per-board trigger/action rules. They are different products.
+- Workflows vs. automations: workflows are standalone objects scoped to a workspace. Automations (create_automation) are per-board trigger/action rules. They are different products.
 - Draft: the editable, inactive version of a workflow. Changes are made on the draft version until it is published as the live version.
 - Privacy: PUBLIC — visible to all workspace members (default). PRIVATE — restricted access. SHAREABLE — accessible to guests outside the account.
 `;

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/create-workflow/create-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/create-workflow/create-workflow-tool.ts
@@ -26,10 +26,10 @@ export const createWorkflowToolSchema = {
 };
 
 export class CreateWorkflowBuilderTool extends BaseMondayApiTool<typeof createWorkflowToolSchema> {
-  name = 'create_workflow_builder';
+  name = 'create_workflow';
   type = ToolType.WRITE;
   annotations = createMondayApiAnnotations({
-    title: 'Create Workflow Builder',
+    title: 'Create Workflow',
     readOnlyHint: false,
     destructiveHint: false,
     idempotentHint: false,


### PR DESCRIPTION
## Summary
- Renames tool \`create_workflow_builder\` → \`create_workflow\`
- Updates annotation title to "Create Workflow"
- Updates all test references
- Bumps version to \`5.16.0\`

## Test plan
- [ ] Unit tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)