### PR TITLE
feat(agent-toolkit): improve automation tool descriptions for agents

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/create-automation/create-automation-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/create-automation/create-automation-tool.ts
@@ -13,8 +13,7 @@ export const createAutomationToolSchema = {
     .trim()
     .min(1, 'userPrompt must be a non-empty string')
     .describe(
-      'Natural-language description of the automation to create. ' +
-        'Describe the trigger, conditions, and what should happen in plain English.',
+      'Structured description of the automation to create.',
     ),
   boardId: z.string().trim().min(1, 'boardId must be a non-empty string').describe('The numeric board ID as a string.'),
 };
@@ -38,16 +37,64 @@ export class CreateAutomationTool extends BaseMondayApiTool<typeof createAutomat
   }
 
   getDescription(): string {
-    return `Creates an automation on a monday board from a natural-language description (e.g. "notify me when status changes to Done").
+    return `
+    Creates an automation on a monday board from a structured natural-language description.
 
-Use when the user has clearly described what to automate — both the trigger (what kicks it off) and the action (what should happen), and you know which board to create it on. If basic details are missing (including boardId), ask the user first instead of calling with a vague prompt.
+Use this tool only when you know:
+- boardId
+- the user's intended trigger
+- at least one intended action
+- any details the user provided that are relevant to the trigger, conditions, or actions
 
-If the prompt is still ambiguous, the tool returns status: "needs_clarification" with the unresolved fields — present them to the user, gather answers, then call again.
+The caller does not need to know the exact available automation blocks or their required fields. Describe the user's intent clearly; the tool will translate that intent into supported blocks and values.
+
+If a required detail is missing from the user's request, ask for clarification before calling the tool.
+
+If the tool returns status: "needs_clarification", present the unresolved fields to the user, gather answers, then call the tool again.
+
+Describe the automation in this format:
+
+Trigger:
+  When <the event that should start the automation>
+  Details:
+    <relevant detail>: <value>
+
+Conditions:
+  - Only if <condition that should be true>
+    Details:
+      <relevant detail>: <value>
+
+Actions:
+  - <action the automation should perform>:
+      <relevant detail>: <value>
+
+Rules:
+- Use one trigger.
+- Conditions are optional.
+- Multiple conditions mean AND.
+- Use one or more actions.
+- Do not use branching.
+- Use natural language, not block IDs or internal field names.
+- Actions may reference values from the trigger context, such as "{{item name}}", "{{creator}}", "{{status}}", "{{group}}", or "{{board}}".
 
 Terminology:
-    - Trigger: When the automation should run (e.g. "when a new item is created").
-    - Conditions: additional conditions that must be met for the automation to run.
-    - Actions: what the automation should do when it runs (can have multiple actions).
+- Trigger: the event that starts the automation, such as "when a new item is created".
+- Conditions: optional requirements that must be true before actions run.
+- Actions: what the automation does when it runs.
+
+Example:
+
+Trigger:
+  When a new item is created
+
+Actions:
+  - Send a notification:
+      Recipient: John Snow
+      Title: Important Update
+      Message: The item "{{item name}}" was created.
+
+  - Move the item to a group:
+      Group: Top group
 `;
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/create-automation/create-automation-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/create-automation/create-automation-tool.ts
@@ -46,7 +46,7 @@ Use this tool only when you know:
 - at least one intended action
 - any details the user provided that are relevant to the trigger, conditions, or actions
 
-The caller does not need to know the exact available automation blocks or their required fields. Describe the user's intent clearly; the tool will translate that intent into supported blocks and values.
+The caller does not need to know the exact available automation blocks or their required fields. Describe the user's intent clearly — the tool will translate that intent into supported blocks and values.
 
 If a required detail is missing from the user's request, ask for clarification before calling the tool.
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.ts
@@ -56,8 +56,9 @@ export class ListAutomationsTool extends BaseMondayApiTool<typeof listAutomation
 
   getDescription(): string {
     return `List all automations on a specific monday.com board, including their ids, titles, active state, and configuration.
-
-When NOT to use: Do not call this tool to get general board information unrelated to automations.`;
+When NOT to use: Do not call this tool to get general board information unrelated to automations.
+Note: Some legacy automations may not appear; mention this if users ask about missing automations.
+`;
   }
 
   getInputSchema() {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflows-tools/list-workflows/list-workflows-tool.ts
@@ -57,7 +57,7 @@ export class ListAutomationsTool extends BaseMondayApiTool<typeof listAutomation
   getDescription(): string {
     return `List all automations on a specific monday.com board, including their ids, titles, active state, and configuration.
 When NOT to use: Do not call this tool to get general board information unrelated to automations.
-Note: Some legacy automations may not appear; mention this if users ask about missing automations.
+Note: Some legacy automations may not appear — mention this if users ask about missing automations.
 `;
   }
 


### PR DESCRIPTION
## Summary

- Expands `create_automation` tool description with a structured Trigger / Conditions / Actions format, usage rules, and an example so agents describe automations consistently before calling the lite-builder API.
- Updates `userPrompt` schema description to match the structured format.
- Adds a note to `list_automations` that some legacy automations may not appear in results.

## Related

https://monday.monday.com/boards/18399225694/views/257773341/pulses/12125775110

## Test plan

- [ ] Verify MCP tool descriptions render correctly for `create_automation` and `list_automations`
- [ ] Confirm agents can follow the structured prompt format when creating automations via the tool


Made with [Cursor](https://cursor.com)