### PR TITLE
feat: add plan_workflow tool

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.22.0
+
+### plan_workflow — new tool
+
+- Adds `plan_workflow` MCP tool that calls the `workflow-planner` platform-agent proxy (`/platform-ai-gateway/agents/workflow-planner`)
+- Takes a single `prompt` (max 2000 chars) describing a process and returns a structured markdown plan: workflow breakdowns, block IDs, Mermaid diagrams, resource definitions, and assumption/gap notes
+- Use before `create_workflow` to understand how to decompose a complex process into individual workflows and which resources to create first
+- Adds `WORKFLOW_PLANNER_AGENT_URL` constant to `workflow-builder-tools/constants.ts`
+
 ## 5.21.0
 
 ### get_board_activity — add user_ids filter

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.21.0",
+  "version": "5.22.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -77,6 +77,7 @@ import { ManageWorkflowsTool } from './workflows-tools/manage-workflows/manage-w
 import { CreateAutomationTool } from './workflows-tools/create-automation/create-automation-tool';
 import { CreateWorkflowBuilderTool } from './workflow-builder-tools/create-workflow/create-workflow-tool';
 import { UpdateWorkflowTool } from './workflow-builder-tools/update-workflow/update-workflow-tool';
+import { PlanWorkflowTool } from './workflow-builder-tools/plan-workflow/plan-workflow-tool';
 import { PublishWorkflowTool } from './workflow-builder-tools/publish-workflow/publish-workflow-tool';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
@@ -164,6 +165,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   CreateWorkflowBuilderTool,
   // Cast: ctor signature (api, apiToken, context?) doesn't match BaseMondayApiToolConstructor.
   UpdateWorkflowTool as unknown as BaseMondayApiToolConstructor,
+  PlanWorkflowTool as unknown as BaseMondayApiToolConstructor,
   PublishWorkflowTool,
 ];
 
@@ -240,6 +242,7 @@ export * from './workflows-tools';
 // Workflow Builder Tools
 export * from './workflow-builder-tools/create-workflow/create-workflow-tool';
 export * from './workflow-builder-tools/update-workflow/update-workflow-tool';
+export * from './workflow-builder-tools/plan-workflow/plan-workflow-tool';
 export * from './workflow-builder-tools/publish-workflow/publish-workflow-tool';
 // Dashboard Tools
 export * from './dashboard-tools';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/constants.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/constants.ts
@@ -1,1 +1,2 @@
 export const WORKFLOW_BUILDER_AGENT_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-builder';
+export const WORKFLOW_PLANNER_AGENT_URL = 'https://api.monday.com/platform-ai-gateway/agents/workflow-planner';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/plan-workflow/plan-workflow-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/plan-workflow/plan-workflow-tool.test.ts
@@ -1,0 +1,122 @@
+import { MondayAgentToolkit } from 'src/mcp/toolkit';
+import { callToolByNameRawAsync, createMockApiClient, parseToolResult } from '../../test-utils/mock-api-client';
+import { WORKFLOW_PLANNER_AGENT_URL } from '../constants';
+
+function mockFetchResponse({
+  ok = true,
+  status = 200,
+  body = {},
+}: {
+  ok?: boolean;
+  status?: number;
+  body?: unknown;
+} = {}): Response {
+  return {
+    ok,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  } as unknown as Response;
+}
+
+describe('PlanWorkflowTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mocks = createMockApiClient();
+    jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+    fetchSpy = jest.spyOn(global, 'fetch');
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it('posts to the workflow-planner agent URL with correct body and Authorization header', async () => {
+    fetchSpy.mockResolvedValue(
+      mockFetchResponse({
+        body: { result: '# Process Plan\n\n## Overview\nThis process requires 2 workflows.' },
+      }),
+    );
+
+    await callToolByNameRawAsync('plan_workflow', {
+      prompt: 'When a deal is marked Won, create a task in the onboarding board and notify the account manager',
+    });
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(url).toBe(WORKFLOW_PLANNER_AGENT_URL);
+    expect(init.method).toBe('POST');
+    expect(init.headers).toMatchObject({
+      Authorization: 'test-token',
+      'Content-Type': 'application/json',
+    });
+    expect(JSON.parse(init.body)).toEqual({
+      prompt: 'When a deal is marked Won, create a task in the onboarding board and notify the account manager',
+    });
+  });
+
+  it('passes through the agent result on success', async () => {
+    const planResult = '# Process Plan\n\n## Overview\nThis process requires 2 workflows.';
+    fetchSpy.mockResolvedValue(
+      mockFetchResponse({
+        body: { result: planResult },
+      }),
+    );
+
+    const result = await callToolByNameRawAsync('plan_workflow', {
+      prompt: 'When a deal is marked Won, notify the account manager',
+    });
+    const parsed = parseToolResult(result);
+
+    expect(parsed.result).toBe(planResult);
+  });
+
+  it('rejects empty prompt before making any HTTP call', async () => {
+    const result = await callToolByNameRawAsync('plan_workflow', {
+      prompt: '   ',
+    });
+
+    expect(result.content[0].text).toContain('prompt must be a non-empty string');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('rejects prompt exceeding 2000 characters before making any HTTP call', async () => {
+    const result = await callToolByNameRawAsync('plan_workflow', {
+      prompt: 'a'.repeat(2001),
+    });
+
+    expect(result.content[0].text).toContain('prompt must not exceed 2000 characters');
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('surfaces the error envelope on 4xx', async () => {
+    fetchSpy.mockResolvedValue(
+      mockFetchResponse({
+        ok: false,
+        status: 400,
+        body: { error: 'Prompt exceeds maximum length of 2000 characters', code: 'PROMPT_TOO_LONG' },
+      }),
+    );
+
+    const result = await callToolByNameRawAsync('plan_workflow', {
+      prompt: 'build an onboarding workflow',
+    });
+
+    expect(result.content[0].text).toContain('Failed to plan workflow');
+    expect(result.content[0].text).toContain('HTTP 400');
+    expect(result.content[0].text).toContain('PROMPT_TOO_LONG');
+  });
+
+  it('wraps network errors with operation context', async () => {
+    fetchSpy.mockRejectedValue(new Error('network failure'));
+
+    const result = await callToolByNameRawAsync('plan_workflow', {
+      prompt: 'build an onboarding workflow',
+    });
+
+    expect(result.content[0].text).toContain('Failed to plan workflow');
+    expect(result.content[0].text).toContain('network failure');
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/plan-workflow/plan-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/plan-workflow/plan-workflow-tool.ts
@@ -1,0 +1,83 @@
+import { ApiClient } from '@mondaydotcomorg/api';
+import { z } from 'zod';
+import { ToolInputType, ToolOutputType, ToolType } from '../../../../tool';
+import { BaseMondayApiTool, MondayApiToolContext, createMondayApiAnnotations } from '../../base-monday-api-tool';
+import { rethrowWithContext } from '../../../../../utils';
+import { WORKFLOW_PLANNER_AGENT_URL } from '../constants';
+
+const REQUEST_TIMEOUT_MS = 180_000;
+
+export const planWorkflowToolSchema = {
+  prompt: z
+    .string()
+    .trim()
+    .min(1, 'prompt must be a non-empty string')
+    .max(2000, 'prompt must not exceed 2000 characters')
+    .describe(
+      'Natural-language description of the process to plan. Describe the full end-to-end process in plain English (e.g. "When a deal is marked Won, create a task in the onboarding board and notify the account manager"). The agent will decompose this into one or more monday.com workflows, identify all required boards and columns, and return a structured implementation plan. Maximum 2000 characters.',
+    ),
+};
+
+export class PlanWorkflowTool extends BaseMondayApiTool<typeof planWorkflowToolSchema> {
+  name = 'plan_workflow';
+  type = ToolType.READ;
+  annotations = createMondayApiAnnotations({
+    title: 'Plan Workflow',
+    readOnlyHint: true,
+    destructiveHint: false,
+    idempotentHint: true,
+  });
+
+  constructor(
+    api: ApiClient,
+    private readonly apiToken: string,
+    context?: MondayApiToolContext,
+  ) {
+    super(api, context);
+  }
+
+  getDescription(): string {
+    return `Plans one or more monday.com workflows for a described process using an AI agent.
+
+The agent analyzes the prompt, decides how many workflows are needed, identifies the required boards and columns, selects the correct trigger and action blocks (with their IDs), and returns a structured implementation plan with Mermaid diagrams and build notes for each workflow.
+
+Use this before create_workflow to understand how to break a complex process into individual workflows and which resources to create first.
+
+Parameters:
+- prompt: describe the full end-to-end process in plain English. Maximum 2000 characters.
+
+Returns:
+- result: structured markdown plan with workflow breakdowns, block IDs, resource definitions, and a list of assumptions and gaps
+`;
+  }
+
+  getInputSchema() {
+    return planWorkflowToolSchema;
+  }
+
+  protected async executeInternal(
+    input: ToolInputType<typeof planWorkflowToolSchema>,
+  ): Promise<ToolOutputType<never>> {
+    try {
+      const response = await fetch(WORKFLOW_PLANNER_AGENT_URL, {
+        method: 'POST',
+        headers: {
+          Authorization: this.apiToken,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prompt: input.prompt }),
+        signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      });
+
+      if (!response.ok) {
+        const body = await response.text().catch(() => '');
+        throw new Error(`workflow-planner responded with HTTP ${response.status}${body ? `: ${body}` : ''}`);
+      }
+
+      const body = (await response.json()) as Record<string, unknown>;
+      return { content: body };
+    } catch (error) {
+      rethrowWithContext(error, 'plan workflow');
+    }
+  }
+}


### PR DESCRIPTION
https://monday.monday.com/boards/18412762536/views/257468344/pulses/12103370039

## Summary
- Adds `plan_workflow` MCP tool that calls `/platform-ai-gateway/agents/workflow-planner`
- Takes a single `prompt` (max 2000 chars) describing an end-to-end process and returns a structured markdown plan with workflow breakdowns, block IDs, Mermaid diagrams, resource definitions, and assumption/gap notes
- Use before `create_workflow` to understand how to decompose a complex process into individual workflows
- Adds `WORKFLOW_PLANNER_AGENT_URL` constant; registers and exports `PlanWorkflowTool` in index

## Test plan
- [x] Unit tests added (6 passing): happy path, empty/oversized prompt validation, 4xx error, network error
- [x] Manually tested against staging `workflow-planner` agent with onboarding process prompt

<img width="955" height="1027" alt="Screenshot 2026-06-01 at 14 01 06" src="https://github.com/user-attachments/assets/edeeedf5-ed70-4389-8e00-4498505a8f1a" />


🤖 Generated with [Claude Code](https://claude.com/claude-code)