### PR TITLE
fix: clarify full board data tool description

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { callToolByNameAsync, callToolByNameRawAsync, createMockApiClient } from '../test-utils/mock-api-client';
 import { ColumnType } from '../../../../monday-graphql/generated/graphql/graphql';
 import { ZodTypeAny } from 'zod';
-import { FullBoardDataToolSchema } from './full-board-data-tool';
+import { FullBoardDataTool, FullBoardDataToolSchema } from './full-board-data-tool';
 import { MondayAgentToolkit } from 'src/mcp/toolkit';
 
 export type inputType = z.objectInputType<FullBoardDataToolSchema, ZodTypeAny>;
@@ -14,6 +14,14 @@ describe('Full Board Data Tool', () => {
     jest.clearAllMocks();
     mocks = createMockApiClient();
     jest.spyOn(MondayAgentToolkit.prototype as any, 'createApiClient').mockReturnValue(mocks.mockApiClient);
+  });
+
+  it('describes when to use the tool without an internal-use warning', () => {
+    const tool = new FullBoardDataTool(mocks.mockApiClient);
+
+    expect(tool.getDescription()).toContain('complete board data');
+    expect(tool.getDescription()).toContain('Prefer narrower board tools');
+    expect(tool.getDescription()).not.toContain('INTERNAL USE ONLY');
   });
 
   const mockBoardResponse = {
@@ -298,7 +306,9 @@ describe('Full Board Data Tool', () => {
     };
 
     const result = await callToolByNameRawAsync('get_full_board_data', args);
-    expect(result.content[0].text).toContain('Failed to get full board data: Invalid board ID, Insufficient permissions');
+    expect(result.content[0].text).toContain(
+      'Failed to get full board data: Invalid board ID, Insufficient permissions',
+    );
   });
 
   it('Extracts user IDs from people column values', async () => {
@@ -364,5 +374,4 @@ describe('Full Board Data Tool', () => {
     expect(userIdsCall).toContain('user789');
     expect(userIdsCall).not.toContain('team456');
   });
-
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts
@@ -31,7 +31,7 @@ export class FullBoardDataTool extends BaseMondayApiTool<typeof fullBoardDataToo
   });
 
   getDescription(): string {
-    return `INTERNAL USE ONLY - DO NOT CALL THIS TOOL DIRECTLY. This tool is exclusively triggered by UI components and should never be invoked directly by the agent.`;
+    return `Fetch complete board data for UI-driven workflows that need items, updates, replies, people values, and user details in one response. Prefer narrower board tools for conversational requests that do not need the full board payload.`;
   }
 
   getInputSchema(): typeof fullBoardDataToolSchema {
@@ -152,7 +152,7 @@ export class FullBoardDataTool extends BaseMondayApiTool<typeof fullBoardDataToo
       };
 
       return {
-        content: result
+        content: result,
       };
     } catch (error) {
       rethrowWithContext(error, 'get full board data');


### PR DESCRIPTION
## Summary

- replace the scary `INTERNAL USE ONLY` full-board-data tool description with clearer guidance
- keep the steer toward narrower board tools for normal conversational requests
- add a focused test so the warning does not come back

## Verification

- `npx prettier@3.2.4 --check packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts --ignore-path .prettierignore`
- `git diff --check`

I also attempted the focused Jest test via `npx`, but this fresh clone has no workspace dependencies installed and the TypeScript Jest config could not resolve `@jest/types` from the temporary `npx` install. I avoided doing a full workspace install for this small copy/test change.

This was implemented with Codex assistance, with the final diff manually reviewed and kept focused.

Closes #366.
