### PR TITLE
chore: bump minor versions for agent-toolkit and monday-api-mcp

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.37.0",
+  "version": "5.38.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/monday-api-mcp/package.json
+++ b/packages/monday-api-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/monday-api-mcp",
-  "version": "3.1.6",
+  "version": "3.2.0",
   "description": "MCP server for using the monday.com API",
   "mcpName": "com.monday/monday.com",
   "license": "MIT",


### PR DESCRIPTION
Bumps minor versions for the two packages:

- `@mondaydotcomorg/agent-toolkit`: 5.37.0 → 5.38.0
- `@mondaydotcomorg/monday-api-mcp`: 3.1.6 → 3.2.0