### PR TITLE
feat(agent-toolkit): include legacy automations in list_automations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-ai",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "monday.com AI repository",
   "private": true,
   "packageManager": "yarn@1.22.21",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "monday-ai",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "monday.com AI repository",
   "private": true,
   "packageManager": "yarn@1.22.21",

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.39.1",
+  "version": "5.40.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/board-automations-query.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/board-automations-query.ts
@@ -3,9 +3,10 @@ import { gql } from 'graphql-request';
 // board_automations is available at runtime for version 2026-10, but the
 // schema snapshot used by codegen does not expose it yet.
 export const getBoardAutomationsQuery = gql`
-  query getBoardAutomations($boardIds: [ID!], $limit: Int, $cursor: String) {
+  query getBoardAutomations($boardIds: [ID!], $limit: Int, $cursor: String, $includeLegacy: Boolean!) {
     board_automations(board_ids: $boardIds, limit: $limit, cursor: $cursor) {
       cursor
+      legacy_automations @include(if: $includeLegacy)
       items {
         id
         user_id
@@ -44,6 +45,9 @@ export interface BoardAutomation {
 export interface BoardAutomationsQuery {
   readonly board_automations: {
     readonly cursor: string | null;
+    // Read-only automations set up in an older way. Present only on the first page
+    // (when includeLegacy is true). Loose passthrough of a frozen, externally-owned contract.
+    readonly legacy_automations?: unknown;
     readonly items: BoardAutomation[] | null;
   } | null;
 }
@@ -52,4 +56,5 @@ export interface BoardAutomationsQueryVariables {
   readonly boardIds?: string[];
   readonly limit?: number;
   readonly cursor?: string;
+  readonly includeLegacy: boolean;
 }

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.test.ts
@@ -59,7 +59,7 @@ describe('ListAutomationsTool', () => {
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.stringContaining('board_automations'),
-      { boardIds: ['1234567890'], limit: 100 },
+      { boardIds: ['1234567890'], limit: 100, includeLegacy: true },
       expect.objectContaining({ versionOverride: '2026-10' }),
     );
     expect(mocks.getMockRequest().mock.calls[0][0]).not.toContain('HostType');
@@ -81,7 +81,7 @@ describe('ListAutomationsTool', () => {
 
     expect(mocks.getMockRequest()).toHaveBeenCalledWith(
       expect.stringContaining('board_automations'),
-      { boardIds: ['1234567890'], cursor: '50', limit: 50 },
+      { boardIds: ['1234567890'], cursor: '50', limit: 50, includeLegacy: false },
       expect.objectContaining({ versionOverride: '2026-10' }),
     );
   });
@@ -94,6 +94,39 @@ describe('ListAutomationsTool', () => {
 
     expect(parsed.workflows).toEqual([]);
     expect(parsed.message).toContain('0');
+  });
+
+  it('should include legacy automations on the first page', async () => {
+    const legacy = { note: 'older automations', automations: [{ id: 1 }], recipes: { recipes: [] } };
+    mocks.setResponseOnce({
+      board_automations: { cursor: null, legacy_automations: legacy, items: [mockBoardAutomation] },
+    });
+
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
+    const parsed = parseToolResult(result);
+
+    expect(parsed.legacyAutomations).toEqual(legacy);
+  });
+
+  it('should request legacy automations only when no cursor is provided', async () => {
+    mocks.setResponseOnce({ board_automations: { cursor: null, items: [] } });
+
+    await callToolByNameRawAsync('list_automations', { boardId: '1234567890', cursor: '50' });
+
+    expect(mocks.getMockRequest()).toHaveBeenCalledWith(
+      expect.stringContaining('board_automations'),
+      expect.objectContaining({ includeLegacy: false }),
+      expect.anything(),
+    );
+  });
+
+  it('should omit legacyAutomations from output when none are returned', async () => {
+    mocks.setResponseOnce({ board_automations: { cursor: null, items: [mockBoardAutomation] } });
+
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
+    const parsed = parseToolResult(result);
+
+    expect(parsed).not.toHaveProperty('legacyAutomations');
   });
 
   it('should propagate GraphQL errors with operation context', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.test.ts
@@ -120,6 +120,22 @@ describe('ListAutomationsTool', () => {
     );
   });
 
+  it('should omit legacyAutomations when the provider returns a best-effort error marker', async () => {
+    mocks.setResponseOnce({
+      board_automations: {
+        cursor: null,
+        legacy_automations: { error: 'Legacy automations could not be retrieved.' },
+        items: [mockBoardAutomation],
+      },
+    });
+
+    const result = await callToolByNameRawAsync('list_automations', { boardId: '1234567890' });
+    const parsed = parseToolResult(result);
+
+    expect(parsed).not.toHaveProperty('legacyAutomations');
+    expect(parsed.workflows).toEqual([expectedWorkflow]);
+  });
+
   it('should omit legacyAutomations from output when none are returned', async () => {
     mocks.setResponseOnce({ board_automations: { cursor: null, items: [mockBoardAutomation] } });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.ts
@@ -25,6 +25,18 @@ function normalizeUserId(userId: BoardAutomation['user_id']): BoardAutomation['u
   return Number.isNaN(parsedUserId) ? userId : parsedUserId;
 }
 
+// The provider's legacy fetch is best-effort: it yields an `{ error }` marker instead of
+// throwing when the internal endpoint fails. Surface real data only; treat the marker as absent.
+function extractLegacyAutomations(legacy: unknown): unknown {
+  if (legacy == null) {
+    return null;
+  }
+  if (typeof legacy === 'object' && 'error' in legacy) {
+    return null;
+  }
+  return legacy;
+}
+
 function mapBoardAutomationToWorkflow(automation: BoardAutomation): WorkflowOutput {
   const { active, user_id: userId, ...workflow } = automation;
 
@@ -85,7 +97,10 @@ When NOT to use: Do not call this tool to get general board information unrelate
 
       const workflows = (res.board_automations?.items ?? []).map(mapBoardAutomationToWorkflow);
       const nextCursor = res.board_automations?.cursor ?? null;
-      const legacyAutomations = includeLegacy ? res.board_automations?.legacy_automations ?? null : null;
+      // legacy_automations is best-effort on the provider: on failure it returns an { error }
+      // marker rather than throwing. Drop that so the model never renders an error as an
+      // automation — the field is already optional ("present both groups" applies to real data).
+      const legacyAutomations = includeLegacy ? extractLegacyAutomations(res.board_automations?.legacy_automations) : null;
 
       return {
         content: {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.ts
@@ -68,7 +68,7 @@ export class ListAutomationsTool extends BaseMondayApiTool<typeof listAutomation
 
   getDescription(): string {
     return `List all automations on a specific monday.com board, including their ids, titles, active state, and configuration.
-Returns two groups: "workflows" (fully manageable; supports pagination via limit/cursor) and "legacyAutomations" (READ-ONLY automations set up in an older way — returned on the first page only, when no cursor is given).
+Returns two groups: "workflows" (fully manageable, supports pagination via limit/cursor) and "legacyAutomations" (READ-ONLY automations set up in an older way — returned on the first page only, when no cursor is given).
 Always present BOTH groups to the user together as one list of board automations — never omit or hide "legacyAutomations". The split and the read-only limitation are internal context for you only: don't volunteer them and don't label any automation "legacy" or "read-only". Only if the user asks to act on a legacy one, briefly explain it can't be changed (e.g. "This one was set up in an older way and can't be modified here").
 When NOT to use: Do not call this tool to get general board information unrelated to automations.
 `;

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/list-automations/list-automations-tool.ts
@@ -56,8 +56,9 @@ export class ListAutomationsTool extends BaseMondayApiTool<typeof listAutomation
 
   getDescription(): string {
     return `List all automations on a specific monday.com board, including their ids, titles, active state, and configuration.
+Returns two groups: "workflows" (fully manageable; supports pagination via limit/cursor) and "legacyAutomations" (READ-ONLY automations set up in an older way — returned on the first page only, when no cursor is given).
+Always present BOTH groups to the user together as one list of board automations — never omit or hide "legacyAutomations". The split and the read-only limitation are internal context for you only: don't volunteer them and don't label any automation "legacy" or "read-only". Only if the user asks to act on a legacy one, briefly explain it can't be changed (e.g. "This one was set up in an older way and can't be modified here").
 When NOT to use: Do not call this tool to get general board information unrelated to automations.
-Note: Some legacy automations may not appear — mention this if users ask about missing automations.
 `;
   }
 
@@ -69,9 +70,12 @@ Note: Some legacy automations may not appear — mention this if users ask about
     input: ToolInputType<typeof listAutomationsToolSchema>,
   ): Promise<ToolOutputType<never>> {
     try {
+      // Legacy automations are board-scoped and only meaningful on the first page (no cursor).
+      const includeLegacy = !input.cursor;
       const variables: BoardAutomationsQueryVariables = {
         boardIds: [input.boardId],
         limit: input.limit ?? DEFAULT_LIMIT,
+        includeLegacy,
         ...(input.cursor ? { cursor: input.cursor } : {}),
       };
 
@@ -81,11 +85,13 @@ Note: Some legacy automations may not appear — mention this if users ask about
 
       const workflows = (res.board_automations?.items ?? []).map(mapBoardAutomationToWorkflow);
       const nextCursor = res.board_automations?.cursor ?? null;
+      const legacyAutomations = includeLegacy ? res.board_automations?.legacy_automations ?? null : null;
 
       return {
         content: {
           message: `Found ${workflows.length} live workflow(s) on board ${input.boardId}`,
           workflows,
+          ...(legacyAutomations != null ? { legacyAutomations } : {}),
           pagination: {
             nextCursor,
             hasMore: nextCursor !== null,


### PR DESCRIPTION
https://monday.monday.com/boards/18399225694/views/257773341/pulses/12334748392
## What
`list_automations` now returns **legacy (old-infra, read-only) automations** alongside live workflows.

## Why
The tool queried `board_automations` for live workflows only, so legacy automations on a board were never returned — the description even warned they "may not appear". This makes the tool's results match what users see on their board.

## How
- Select the new `legacy_automations` field on `board_automations`, gated to the **first page** via `@include(if: $includeLegacy)` (`includeLegacy = !cursor`) so pagination requests don't trigger the extra board-scoped fetch.
- Surface the result as `legacyAutomations` in the tool output (omitted when none returned).
- Updated the tool description to instruct presenting both groups together as one list, while keeping the workflows/legacy split and read-only limitation as internal context.

## Testing
- `jest list-automations` — 10 passed (incl. new legacy-present / first-page-only / omitted cases).
- `tsc --noEmit` clean.

## Deploy ordering
Depends on the lite-builder provider PR exposing `legacy_automations` — that must be deployed **first**, otherwise the query errors on an unknown field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)