### PR TITLE
chore(agent-toolkit): bump version to 5.40.0

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.39.1",
+  "version": "5.40.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
## Summary

Bumps `@mondaydotcomorg/agent-toolkit` from `5.39.1` → `5.40.0` to trigger a clean build and publish.

The `all_api_read` tool was merged in #399 and exists on master, but the published `5.39.1` dist was built before that merge — the compiled bundle is missing the tool. This bump ensures the next publish compiles from the current master and includes `all_api_read` in `dist/`.

**monday.com item:** https://monday.monday.com/boards/8222767873/views/176581153/pulses/12329877553

🤖 Generated with [Claude Code](https://claude.com/claude-code)