### PR TITLE
Skip Authorization header when a custom fetch is configured

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.40.1",
+  "version": "5.40.2",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/create-automation/create-automation-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/automations-tools/create-automation/create-automation-tool.ts
@@ -113,7 +113,7 @@ Actions:
         path: LITE_BUILDER_AGENT_PATH,
         method: 'POST',
         headers: {
-          Authorization: apiToken,
+          ...(this.context?.fetchConfig?.fetch ? {} : { Authorization: apiToken }),
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/plan-workflow/plan-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/plan-workflow/plan-workflow-tool.ts
@@ -66,7 +66,7 @@ Returns:
         path: WORKFLOW_PLANNER_AGENT_PATH,
         method: 'POST',
         headers: {
-          Authorization: apiToken,
+          ...(this.context?.fetchConfig?.fetch ? {} : { Authorization: apiToken }),
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({ prompt: input.prompt }),

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/update-workflow/update-workflow-tool.ts
@@ -83,7 +83,7 @@ Note: the workflow runs only after it is published to live version.
         path: WORKFLOW_BUILDER_AGENT_PATH,
         method: 'POST',
         headers: {
-          Authorization: apiToken,
+          ...(this.context?.fetchConfig?.fetch ? {} : { Authorization: apiToken }),
           'Content-Type': 'application/json',
         },
         body: JSON.stringify({


### PR DESCRIPTION
## Summary
Three platform-agent tools (`plan_workflow`, `update_workflow`, `create_automation`) attach the user's api.monday.com token as `Authorization`. When a custom `fetchConfig.fetch` routes the call through internal infra (e.g. the MCP gateway's trident fetch), that header short-circuits trident's auto-sign and the destination rejects the request as unauthenticated.

This PR only attaches `Authorization` when no custom fetch is configured — the default `https://api.monday.com` flow is unchanged.

## Changes
- `plan-workflow-tool.ts`, `update-workflow-tool.ts`, `create-automation-tool.ts`: gate `Authorization` on the absence of `this.context?.fetchConfig?.fetch`.
- `package.json`: bump to `5.40.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)