### PR TITLE
feat(agent-toolkit): add all_api_write tool, bump to 5.43.0

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.42.0",
+  "version": "5.43.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/all-api-write-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/all-api-write-tool.test.ts
@@ -1,0 +1,31 @@
+import { AllApiWriteTool } from './all-api-write-tool';
+import { createMockApiClient } from './test-utils/mock-api-client';
+
+describe('AllApiWriteTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    mocks = createMockApiClient();
+  });
+
+  it('throws when given a query', async () => {
+    const tool = new AllApiWriteTool(mocks.mockApiClient);
+
+    await expect(
+      tool.execute({ query: 'query { boards { id } }', variables: '{}' }),
+    ).rejects.toThrow('all_api_write only accepts mutations. Read queries are not allowed.');
+  });
+
+  it('does not throw when given a mutation', async () => {
+    const tool = new AllApiWriteTool(mocks.mockApiClient);
+    jest.spyOn(tool as any, 'validateOperation').mockResolvedValue([]);
+    mocks.setResponse({ create_item: { id: '123' } });
+
+    await expect(
+      tool.execute({
+        query: 'mutation { create_item(board_id: 1, item_name: "test") { id } }',
+        variables: '{}',
+      }),
+    ).resolves.toBeDefined();
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/all-api-write-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/all-api-write-tool.ts
@@ -1,0 +1,34 @@
+import { parse, getOperationAST, OperationTypeNode } from 'graphql';
+import { AllMondayApiTool, allMondayApiToolSchema } from './all-monday-api-tool';
+import { ToolInputType, ToolOutputType, ToolType } from '../../tool';
+import { createMondayApiAnnotations, MondayApiToolContext } from './base-monday-api-tool';
+import { ApiClient } from '@mondaydotcomorg/api';
+
+export class AllApiWriteTool extends AllMondayApiTool {
+  name = 'all_api_write';
+  type = ToolType.WRITE;
+  annotations = createMondayApiAnnotations({
+    title: 'Run Mutation on the monday.com API',
+    readOnlyHint: false,
+    destructiveHint: true,
+    idempotentHint: false,
+  });
+
+  constructor(mondayApi: ApiClient, context?: MondayApiToolContext) {
+    super(mondayApi, context);
+  }
+
+  getDescription(): string {
+    return 'Execute GraphQL mutations against the monday.com API to create, update, or delete data. Only mutations are accepted — queries are rejected with an error before the request is sent. Use get_graphql_schema and get_type_details tools first to understand the schema before crafting your mutation.';
+  }
+
+  protected async executeInternal(input: ToolInputType<typeof allMondayApiToolSchema>): Promise<ToolOutputType<never>> {
+    const operation = getOperationAST(parse(input.query));
+
+    if (operation && operation.operation !== OperationTypeNode.MUTATION) {
+      throw new Error('all_api_write only accepts mutations. Read queries are not allowed.');
+    }
+
+    return super.executeInternal(input);
+  }
+}

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -1,5 +1,6 @@
 import { AllMondayApiTool } from './all-monday-api-tool';
 import { AllApiReadTool } from './all-api-read-tool';
+import { AllApiWriteTool } from './all-api-write-tool';
 import { BaseMondayApiToolConstructor } from './base-monday-api-tool';
 import { ChangeItemColumnValuesTool } from './change-item-column-values-tool';
 import { GetObjectSchemasTool } from './get-object-schemas-tool/get-object-schemas-tool';
@@ -115,6 +116,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   DeleteColumnTool,
   AllMondayApiTool,
   AllApiReadTool,
+  AllApiWriteTool,
   GetGraphQLSchemaTool,
   GetColumnTypeInfoTool,
   GetTypeDetailsTool,
@@ -186,6 +188,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
 
 export * from './all-monday-api-tool';
 export * from './all-api-read-tool';
+export * from './all-api-write-tool';
 export * from './get-object-schemas-tool/get-object-schemas-tool';
 export * from './create-object-schema-tool/create-object-schema-tool';
 export * from './update-object-schema-tool/update-object-schema-tool';


### PR DESCRIPTION
https://monday.monday.com/boards/8222767873/views/176581153/pulses/12389440958
## Summary

Re-adds `all_api_write` — a mutations-only counterpart to `all_api_read`.

Rejects any non-mutation GraphQL operation at parse time (before the request is sent), symmetric with how `all_api_read` rejects mutations.

This is part of a broader migration plan: expose all three tools (`all_monday_api`, `all_api_read`, `all_api_write`) to MCP clients, migrate clients to use the split tools, then remove `all_monday_api`.

## Changes
- `all-api-write-tool.ts` — new tool, extends `AllMondayApiTool`, `ToolType.WRITE`
- `all-api-write-tool.test.ts` — throws on query, passes on mutation
- `index.ts` — registered and exported
- `package.json` — bumped `5.42.0 → 5.43.0`

## Test plan
- [ ] Passing a `mutation { ... }` to `all_api_write` — succeeds
- [ ] Passing a `query { ... }` to `all_api_write` — throws error
- [ ] `all_api_read` and `all_monday_api` behaviour unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)