### PR TITLE
fix(agent-toolkit): clarify full board data helper description

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { callToolByNameAsync, callToolByNameRawAsync, createMockApiClient } from '../test-utils/mock-api-client';
 import { ColumnType } from '../../../../monday-graphql/generated/graphql/graphql';
 import { ZodTypeAny } from 'zod';
-import { FullBoardDataToolSchema } from './full-board-data-tool';
+import { FullBoardDataTool, FullBoardDataToolSchema } from './full-board-data-tool';
 import { MondayAgentToolkit } from 'src/mcp/toolkit';
 
 export type inputType = z.objectInputType<FullBoardDataToolSchema, ZodTypeAny>;
@@ -109,6 +109,15 @@ describe('Full Board Data Tool', () => {
       },
     ],
   };
+
+  it('describes when agents should use the full board data helper', () => {
+    const tool = new FullBoardDataTool(mocks.mockApiClient);
+    const description = tool.getDescription();
+
+    expect(description).toContain('another monday.com tool explicitly asks');
+    expect(description).toContain('prefer narrower board or item tools');
+    expect(description).not.toContain('DO NOT CALL THIS TOOL DIRECTLY');
+  });
 
   it('Successfully fetches board data with items, updates, and enriches with user info', async () => {
     // Setup mock to return different responses for each query

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.ts
@@ -31,7 +31,7 @@ export class FullBoardDataTool extends BaseMondayApiTool<typeof fullBoardDataToo
   });
 
   getDescription(): string {
-    return `INTERNAL USE ONLY - DO NOT CALL THIS TOOL DIRECTLY. This tool is exclusively triggered by UI components and should never be invoked directly by the agent.`;
+    return `Fetch complete board data for UI display workflows. Use this only when another monday.com tool explicitly asks for full board data before showing a table. Otherwise prefer narrower board or item tools.`;
   }
 
   getInputSchema(): typeof fullBoardDataToolSchema {


### PR DESCRIPTION
## Summary
- replace the hard "DO NOT CALL THIS TOOL DIRECTLY" warning on `get_full_board_data` with guidance for the intended UI-display workflow
- add a focused metadata test so the helper description keeps explaining when agents should use narrower tools instead

Closes #366

## Verification
- `../../node_modules/.bin/jest -c jest.config.ts src/core/tools/platform-api-tools/full-board-data-tool/full-board-data-tool.test.ts --runInBand`
- `../../node_modules/.bin/jest -c jest.config.ts src/core/tools/tool-description-safety.test.ts --runInBand`

Note: verified locally under Node 22.17.1 because this machine does not have the repo CI version Node 20.18.1 installed.