### PR TITLE
fix: mcp publish execute only if explicitly requested

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.53.1
+
+### publish_workflow — restrict to explicit user request
+
+- Added "When to use" guidance to the tool description instructing the LLM to only call `publish_workflow` when the user explicitly asks to publish
+- After workflow creation/update, the LLM will suggest publishing and wait for user confirmation before proceeding
+
 ## 5.49.0
 
 ### search — normalize searchType and limit inputs

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.53.0",
+  "version": "5.53.1",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/publish-workflow/publish-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workflow-builder-tools/publish-workflow/publish-workflow-tool.ts
@@ -42,7 +42,9 @@ export class PublishWorkflowTool extends BaseMondayApiTool<typeof publishWorkflo
   getDescription(): string {
     return `Publishes a workflow draft, promoting it to the live version.
 
-Use this after create_workflow (and optionally update_workflow) to make the workflow active. Before publishing, the workflow is validated — if it has missing or misconfigured steps, publish will fail with a WORKFLOW_VALIDATION_FAILED error that includes structured issue details: which step failed, the issue type, and which inputs are missing. Use those details to guide the user on what to fix before retrying.
+When to use: Only call this tool when the user explicitly asks to publish the workflow. After a workflow is created or updated successfully, suggest to the user that they can publish it and wait for their explicit confirmation before proceeding.
+
+Before publishing, the workflow is validated — if it has missing or misconfigured steps, publish will fail with a WORKFLOW_VALIDATION_FAILED error that includes structured issue details: which step failed, the issue type, and which inputs are missing. Use those details to guide the user on what to fix before retrying.
 
 Parameters:
 - workflowObjectId and workflowDraftId: returned by create_workflow — they identify which draft to publish.


### PR DESCRIPTION
https://monday.monday.com/boards/18412762536/pulses/12452308748

## Summary
- Add "When to use" guidance to `publish_workflow` tool description so the LLM only calls it on explicit user request
- After workflow creation/update, the LLM will suggest publishing and wait for user confirmation
<img width="638" height="180" alt="Screenshot 2026-07-06 at 14 52 36" src="https://github.com/user-attachments/assets/f5a0b0b8-2226-4155-aaad-6076292f6a79" />

## Test plan
- [x] Unit tests pass (verified locally)
- [x] Test with MCP client: create a workflow → verify the LLM suggests publishing but doesn't auto-publish