### PR TITLE
fix(agent-toolkit): count GraphQL root fields for BigBrain observability

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.55.0",
+  "version": "5.56.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/all-monday-api-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/all-monday-api-tool.test.ts
@@ -1,3 +1,4 @@
+import { parse } from 'graphql';
 import { AllMondayApiTool } from './all-monday-api-tool';
 import type { ApiClient } from '@mondaydotcomorg/api';
 
@@ -51,12 +52,84 @@ describe('AllMondayApiTool', () => {
     );
 
     expect(sessionContext.metadata).toEqual({
-      graphql_queries: { GetBoards: 1 },
-      graphql_mutations: { CreateItem: 1 },
+      graphql_queries: { boards: 1 },
+      graphql_mutations: { create_item: 1 },
     });
   });
 
-  it('uses root field name when operation is anonymous', async () => {
+  it('counts create_item twice for aliased fields in a named mutation', async () => {
+    const mockRequest = jest.fn().mockResolvedValue({
+      item1: { id: '1', name: 'Test item 1 from all_monday_api', url: 'https://example.com/1' },
+      item2: { id: '2', name: 'Test item 2 from all_monday_api', url: 'https://example.com/2' },
+    });
+    const tool = new AllMondayApiTool({ request: mockRequest } as unknown as ApiClient);
+    jest.spyOn(tool as unknown as { validateOperation: () => Promise<string[]> }, 'validateOperation').mockResolvedValue([]);
+
+    const input = {
+      query: `mutation CreateTwoItems($boardId: ID!) {
+  item1: create_item(board_id: $boardId, item_name: "Test item 1 from all_monday_api") {
+    id
+    name
+    url
+  }
+  item2: create_item(board_id: $boardId, item_name: "Test item 2 from all_monday_api") {
+    id
+    name
+    url
+  }
+}`,
+      variables: '{"boardId":"143193795"}',
+    };
+
+    const sessionContext = { metadata: {} as Record<string, unknown> };
+
+    await tool.execute(input, sessionContext);
+
+    expect(sessionContext.metadata).toEqual({
+      graphql_queries: {},
+      graphql_mutations: { create_item: 2 },
+    });
+    expect(sessionContext.metadata.graphql_mutations).not.toHaveProperty('CreateTwoItems');
+  });
+
+  it('counts duplicate operations in a single call', async () => {
+    const mockRequest = jest.fn().mockResolvedValue({ create_item: { id: '1' } });
+    const tool = new AllMondayApiTool({ request: mockRequest } as unknown as ApiClient);
+    jest.spyOn(tool as unknown as { validateOperation: () => Promise<string[]> }, 'validateOperation').mockResolvedValue([]);
+
+    const query = `
+      mutation CreateItem($boardId: ID!, $itemName: String!) {
+        create_item(board_id: $boardId, item_name: $itemName) { id }
+      }
+      mutation CreateItem($boardId: ID!, $itemName: String!) {
+        create_item(board_id: $boardId, item_name: $itemName) { id }
+      }
+    `;
+
+    const counts = (
+      tool as unknown as {
+        countGraphqlOperations: (doc: ReturnType<typeof parse>) => {
+          graphql_queries: Record<string, number>;
+          graphql_mutations: Record<string, number>;
+        };
+      }
+    ).countGraphqlOperations(parse(query));
+
+    const sessionContext = { metadata: {} as Record<string, unknown> };
+
+    await tool.execute({ query, variables: '{}' }, sessionContext);
+
+    expect(counts).toEqual({
+      graphql_queries: {},
+      graphql_mutations: { create_item: 2 },
+    });
+    expect(sessionContext.metadata).toEqual({
+      graphql_queries: {},
+      graphql_mutations: { create_item: 2 },
+    });
+  });
+
+  it('uses root field name for anonymous operations', async () => {
     const mockRequest = jest.fn().mockResolvedValue({ boards: [{ id: '1' }] });
     const tool = new AllMondayApiTool({ request: mockRequest } as unknown as ApiClient);
     jest.spyOn(tool as unknown as { validateOperation: () => Promise<string[]> }, 'validateOperation').mockResolvedValue([]);

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/all-monday-api-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/all-monday-api-tool.ts
@@ -6,7 +6,6 @@ import {
   DocumentNode,
   GraphQLSchema,
   IntrospectionQuery,
-  OperationDefinitionNode,
   OperationTypeNode,
   parse,
   validate,
@@ -86,29 +85,28 @@ export class AllMondayApiTool extends BaseMondayApiTool<typeof allMondayApiToolS
         continue;
       }
 
-      const operationKey = this.getGraphqlOperationKey(definition);
+      const counts =
+        definition.operation === OperationTypeNode.MUTATION
+          ? graphql_mutations
+          : definition.operation === OperationTypeNode.QUERY
+            ? graphql_queries
+            : null;
 
-      if (definition.operation === OperationTypeNode.MUTATION) {
-        graphql_mutations[operationKey] = (graphql_mutations[operationKey] ?? 0) + 1;
-      } else if (definition.operation === OperationTypeNode.QUERY) {
-        graphql_queries[operationKey] = (graphql_queries[operationKey] ?? 0) + 1;
+      if (!counts) {
+        continue;
+      }
+
+      for (const selection of definition.selectionSet.selections) {
+        if (selection.kind !== 'Field') {
+          continue;
+        }
+
+        const fieldKey = selection.name.value;
+        counts[fieldKey] = (counts[fieldKey] ?? 0) + 1;
       }
     }
 
     return { graphql_queries, graphql_mutations };
-  }
-
-  private getGraphqlOperationKey(definition: OperationDefinitionNode): string {
-    if (definition.name?.value) {
-      return definition.name.value;
-    }
-
-    const firstSelection = definition.selectionSet.selections[0];
-    if (firstSelection?.kind === 'Field') {
-      return firstSelection.name.value;
-    }
-
-    return '<anonymous>';
   }
 
   protected recordGraphqlOperationCounts(documentAST: DocumentNode): void {


### PR DESCRIPTION
## Summary
- Count root GraphQL field names (`create_item`, `boards`, etc.) instead of operation names when populating `graphql_queries` / `graphql_mutations` session metadata
- Fixes aliased mutations (e.g. two `create_item` fields in one `CreateTwoItems` mutation) reporting `create_item: 2` instead of `CreateTwoItems: 1` on BigBrain `mcp-request` events
- Adds tests covering the ChatGPT reproduction case and duplicate operations in a single document

## Test plan
- [x] `npx jest packages/agent-toolkit/src/core/tools/platform-api-tools/all-monday-api-tool.test.ts`
- [x] `npx jest packages/agent-toolkit/src/core/tools/platform-api-tools/all-api-read-tool.test.ts`
- [x] `npx jest packages/agent-toolkit/src/core/tools/platform-api-tools/all-api-write-tool.test.ts`
- [ ] Verify BigBrain `mcp-request` payload shows `graphql_mutations: { create_item: 2 }` for aliased multi-create mutations via platform-mcp-gateway


Made with [Cursor](https://cursor.com)