### PR TITLE
feat(agent-toolkit): add send_feedback tool

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.56.2",
+  "version": "5.57.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -88,6 +88,7 @@ import { PlanWorkflowTool } from './workflow-builder-tools/plan-workflow/plan-wo
 import { PublishWorkflowTool } from './workflow-builder-tools/publish-workflow/publish-workflow-tool';
 import { ConfigureAiColumnTool } from './configure-ai-column-tool/configure-ai-column-tool';
 import { RemoveAiFromColumnTool } from './remove-ai-from-column-tool/remove-ai-from-column-tool';
+import { SendFeedbackTool } from './send-feedback-tool';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   DeleteItemTool,
@@ -186,6 +187,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   // AI Column Tools
   ConfigureAiColumnTool,
   RemoveAiFromColumnTool,
+  SendFeedbackTool,
 ];
 
 export * from './all-monday-api-tool';
@@ -272,5 +274,6 @@ export * from './dashboard-tools';
 // AI Column Tools
 export * from './configure-ai-column-tool/configure-ai-column-tool';
 export * from './remove-ai-from-column-tool/remove-ai-from-column-tool';
+export * from './send-feedback-tool';
 // Monday Dev Tools
 export * from '../monday-dev-tools';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -88,7 +88,7 @@ import { PlanWorkflowTool } from './workflow-builder-tools/plan-workflow/plan-wo
 import { PublishWorkflowTool } from './workflow-builder-tools/publish-workflow/publish-workflow-tool';
 import { ConfigureAiColumnTool } from './configure-ai-column-tool/configure-ai-column-tool';
 import { RemoveAiFromColumnTool } from './remove-ai-from-column-tool/remove-ai-from-column-tool';
-import { SendFeedbackTool } from './send-feedback-tool';
+import { SendFeedbackTool } from './send-feedback-tool/send-feedback-tool';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   DeleteItemTool,
@@ -274,6 +274,6 @@ export * from './dashboard-tools';
 // AI Column Tools
 export * from './configure-ai-column-tool/configure-ai-column-tool';
 export * from './remove-ai-from-column-tool/remove-ai-from-column-tool';
-export * from './send-feedback-tool';
+export * from './send-feedback-tool/send-feedback-tool';
 // Monday Dev Tools
 export * from '../monday-dev-tools';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/index.ts
@@ -1,1 +1,0 @@
-export { SendFeedbackTool, sendFeedbackToolSchema } from './send-feedback-tool';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/index.ts
@@ -1,0 +1,1 @@
+export { SendFeedbackTool, sendFeedbackToolSchema } from './send-feedback-tool';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
@@ -17,7 +17,7 @@ describe('SendFeedbackTool', () => {
   });
 
   it('fires a mcp_feedback_submitted BigBrain event with all fields', async () => {
-    const tool = new SendFeedbackTool(mocks.mockApiClient, 'test-token', {
+    const tool = new SendFeedbackTool(mocks.mockApiClient, {
       agentType: 'monday_agent',
       agentClientName: 'my-client',
     });
@@ -63,8 +63,7 @@ describe('SendFeedbackTool', () => {
     expect(eventData).not.toHaveProperty('agent_client_name');
   });
 
-  it('extracts account and user id from a valid JWT token', async () => {
-    // JWT with payload: { actid: 12345, uid: 67890, aai: 111, tid: 222, rgn: 'use1', per: 'me:rw' }
+  it('extracts account and user id from the ApiClient token', async () => {
     const payload = { actid: 12345, uid: 67890, aai: 111, tid: 222, rgn: 'use1', per: 'me:rw' };
     const base64urlPayload = Buffer.from(JSON.stringify(payload))
       .toString('base64')
@@ -73,7 +72,8 @@ describe('SendFeedbackTool', () => {
       .replace(/=/g, '');
     const token = `eyJhbGciOiJIUzI1NiJ9.${base64urlPayload}.signature`;
 
-    const tool = new SendFeedbackTool(mocks.mockApiClient, token);
+    const mockClientWithToken = { ...mocks.mockApiClient, token };
+    const tool = new SendFeedbackTool(mockClientWithToken as any);
 
     await tool.execute({
       kind: 'feature_request',

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
@@ -32,6 +32,10 @@ describe('SendFeedbackTool', () => {
     expect(mockTrackEvent).toHaveBeenCalledTimes(1);
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: 'mcp_feedback_submitted',
+      kind: 'bug',
+      info1: 'create_item fails on large boards',
+      info2: 'monday_agent',
+      info3: 'create_item',
       data: expect.objectContaining({
         kind: 'bug',
         title: 'create_item fails on large boards',
@@ -82,11 +86,14 @@ describe('SendFeedbackTool', () => {
     });
 
     const eventData = mockTrackEvent.mock.calls[0][0].data;
-    expect(eventData).toMatchObject({ account_id: 12345, user_id: 67890, api_app_id: 111, region: 'use1', team_id: 222 });
+    // top-level root fields (camelCase params → pulse_ in request body)
+    const event = mockTrackEvent.mock.calls[0][0];
+    expect(event).toMatchObject({ accountId: 12345, userId: 67890 });
+    // data fields
+    expect(eventData).toMatchObject({ account_id: 12345, user_id: 67890, api_app_id: 111, region: 'use1' });
     expect(eventData).not.toHaveProperty('actid');
     expect(eventData).not.toHaveProperty('uid');
     expect(eventData).not.toHaveProperty('aai');
     expect(eventData).not.toHaveProperty('rgn');
-    expect(eventData).not.toHaveProperty('tid');
   });
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
@@ -1,0 +1,87 @@
+import { createMockApiClient } from '../test-utils/mock-api-client';
+import { SendFeedbackTool } from './send-feedback-tool';
+import { trackEvent } from '../../../../utils/tracking.utils';
+
+jest.mock('../../../../utils/tracking.utils', () => ({
+  trackEvent: jest.fn(),
+}));
+
+const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>;
+
+describe('SendFeedbackTool', () => {
+  let mocks: ReturnType<typeof createMockApiClient>;
+
+  beforeEach(() => {
+    mocks = createMockApiClient();
+    jest.clearAllMocks();
+  });
+
+  it('fires a mcp_feedback_submitted BigBrain event with all fields', async () => {
+    const tool = new SendFeedbackTool(mocks.mockApiClient, 'test-token', {
+      agentType: 'monday_agent',
+      agentClientName: 'my-client',
+    });
+
+    const result = await tool.execute({
+      feedback_type: 'bug_report',
+      title: 'create_item fails on large boards',
+      description: 'When the board has more than 500 items, create_item returns a timeout error.',
+      tool_name: 'create_item',
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    expect(mockTrackEvent).toHaveBeenCalledWith({
+      name: 'mcp_feedback_submitted',
+      data: expect.objectContaining({
+        feedback_type: 'bug_report',
+        title: 'create_item fails on large boards',
+        description: 'When the board has more than 500 items, create_item returns a timeout error.',
+        tool_name: 'create_item',
+        agent_type: 'monday_agent',
+        agent_client_name: 'my-client',
+      }),
+    });
+
+    expect(result.content).toEqual(
+      expect.objectContaining({ message: expect.stringContaining('submitted successfully') }),
+    );
+  });
+
+  it('omits optional fields when not provided', async () => {
+    const tool = new SendFeedbackTool(mocks.mockApiClient);
+
+    await tool.execute({
+      feedback_type: 'feedback',
+      title: 'Great tool!',
+      description: 'Really helpful for automation.',
+    });
+
+    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
+    const eventData = mockTrackEvent.mock.calls[0][0].data;
+    expect(eventData).not.toHaveProperty('tool_name');
+    expect(eventData).not.toHaveProperty('agent_type');
+    expect(eventData).not.toHaveProperty('agent_client_name');
+  });
+
+  it('extracts account and user id from a valid JWT token', async () => {
+    // JWT with payload: { actid: 12345, uid: 67890, aai: 111, tid: 222, rgn: 'use1', per: 'me:rw' }
+    const payload = { actid: 12345, uid: 67890, aai: 111, tid: 222, rgn: 'use1', per: 'me:rw' };
+    const base64urlPayload = Buffer.from(JSON.stringify(payload))
+      .toString('base64')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
+      .replace(/=/g, '');
+    const token = `eyJhbGciOiJIUzI1NiJ9.${base64urlPayload}.signature`;
+
+    const tool = new SendFeedbackTool(mocks.mockApiClient, token);
+
+    await tool.execute({
+      feedback_type: 'feature_request',
+      title: 'Support batch operations',
+      description: 'Allow updating multiple items at once.',
+    });
+
+    const eventData = mockTrackEvent.mock.calls[0][0].data;
+    expect(eventData).toMatchObject({ actid: 12345, uid: 67890, aai: 111, rgn: 'use1' });
+  });
+});

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
@@ -82,6 +82,11 @@ describe('SendFeedbackTool', () => {
     });
 
     const eventData = mockTrackEvent.mock.calls[0][0].data;
-    expect(eventData).toMatchObject({ actid: 12345, uid: 67890, aai: 111, rgn: 'use1' });
+    expect(eventData).toMatchObject({ account_id: 12345, user_id: 67890, api_app_id: 111, region: 'use1', team_id: 222 });
+    expect(eventData).not.toHaveProperty('actid');
+    expect(eventData).not.toHaveProperty('uid');
+    expect(eventData).not.toHaveProperty('aai');
+    expect(eventData).not.toHaveProperty('rgn');
+    expect(eventData).not.toHaveProperty('tid');
   });
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
@@ -1,49 +1,32 @@
 import { createMockApiClient } from '../test-utils/mock-api-client';
 import { SendFeedbackTool } from './send-feedback-tool';
-import { trackEvent } from '../../../../utils/tracking.utils';
-
-jest.mock('../../../../utils/tracking.utils', () => ({
-  trackEvent: jest.fn(),
-}));
-
-const mockTrackEvent = trackEvent as jest.MockedFunction<typeof trackEvent>;
 
 describe('SendFeedbackTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
 
   beforeEach(() => {
     mocks = createMockApiClient();
-    jest.clearAllMocks();
   });
 
-  it('fires a mcp_feedback_submitted BigBrain event with all fields', async () => {
-    const tool = new SendFeedbackTool(mocks.mockApiClient, {
-      agentType: 'monday_agent',
-      agentClientName: 'my-client',
-    });
+  it('sets session context metadata with all fields', async () => {
+    const tool = new SendFeedbackTool(mocks.mockApiClient);
+    const sessionContext = { metadata: {} as Record<string, unknown> };
 
-    const result = await tool.execute({
-      kind: 'bug',
-      title: 'create_item fails on large boards',
-      description: 'When the board has more than 500 items, create_item returns a timeout error.',
-      tool_name: 'create_item',
-    });
-
-    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-    expect(mockTrackEvent).toHaveBeenCalledWith({
-      name: 'mcp_feedback_submitted',
-      kind: 'bug',
-      info1: 'create_item fails on large boards',
-      info2: 'monday_agent',
-      info3: 'create_item',
-      data: expect.objectContaining({
+    const result = await tool.execute(
+      {
         kind: 'bug',
         title: 'create_item fails on large boards',
         description: 'When the board has more than 500 items, create_item returns a timeout error.',
         tool_name: 'create_item',
-        agent_type: 'monday_agent',
-        agent_client_name: 'my-client',
-      }),
+      },
+      sessionContext,
+    );
+
+    expect(sessionContext.metadata).toMatchObject({
+      kind: 'bug',
+      title: 'create_item fails on large boards',
+      description: 'When the board has more than 500 items, create_item returns a timeout error.',
+      tool_name: 'create_item',
     });
 
     expect(result.content).toEqual(
@@ -51,49 +34,24 @@ describe('SendFeedbackTool', () => {
     );
   });
 
-  it('omits optional fields when not provided', async () => {
+  it('omits tool_name from metadata when not provided', async () => {
     const tool = new SendFeedbackTool(mocks.mockApiClient);
+    const sessionContext = { metadata: {} as Record<string, unknown> };
 
-    await tool.execute({
+    await tool.execute(
+      {
+        kind: 'feedback',
+        title: 'Great tool!',
+        description: 'Really helpful for automation.',
+      },
+      sessionContext,
+    );
+
+    expect(sessionContext.metadata).not.toHaveProperty('tool_name');
+    expect(sessionContext.metadata).toMatchObject({
       kind: 'feedback',
       title: 'Great tool!',
       description: 'Really helpful for automation.',
     });
-
-    expect(mockTrackEvent).toHaveBeenCalledTimes(1);
-    const eventData = mockTrackEvent.mock.calls[0][0].data;
-    expect(eventData).not.toHaveProperty('tool_name');
-    expect(eventData).not.toHaveProperty('agent_type');
-    expect(eventData).not.toHaveProperty('agent_client_name');
-  });
-
-  it('extracts account and user id from the ApiClient token', async () => {
-    const payload = { actid: 12345, uid: 67890, aai: 111, tid: 222, rgn: 'use1', per: 'me:rw' };
-    const base64urlPayload = Buffer.from(JSON.stringify(payload))
-      .toString('base64')
-      .replace(/\+/g, '-')
-      .replace(/\//g, '_')
-      .replace(/=/g, '');
-    const token = `eyJhbGciOiJIUzI1NiJ9.${base64urlPayload}.signature`;
-
-    const mockClientWithToken = { ...mocks.mockApiClient, token };
-    const tool = new SendFeedbackTool(mockClientWithToken as any);
-
-    await tool.execute({
-      kind: 'feature_request',
-      title: 'Support batch operations',
-      description: 'Allow updating multiple items at once.',
-    });
-
-    const eventData = mockTrackEvent.mock.calls[0][0].data;
-    // top-level root fields (camelCase params → pulse_ in request body)
-    const event = mockTrackEvent.mock.calls[0][0];
-    expect(event).toMatchObject({ accountId: 12345, userId: 67890 });
-    // data fields
-    expect(eventData).toMatchObject({ account_id: 12345, user_id: 67890, api_app_id: 111, region: 'use1' });
-    expect(eventData).not.toHaveProperty('actid');
-    expect(eventData).not.toHaveProperty('uid');
-    expect(eventData).not.toHaveProperty('aai');
-    expect(eventData).not.toHaveProperty('rgn');
   });
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.test.ts
@@ -23,7 +23,7 @@ describe('SendFeedbackTool', () => {
     });
 
     const result = await tool.execute({
-      feedback_type: 'bug_report',
+      kind: 'bug',
       title: 'create_item fails on large boards',
       description: 'When the board has more than 500 items, create_item returns a timeout error.',
       tool_name: 'create_item',
@@ -33,7 +33,7 @@ describe('SendFeedbackTool', () => {
     expect(mockTrackEvent).toHaveBeenCalledWith({
       name: 'mcp_feedback_submitted',
       data: expect.objectContaining({
-        feedback_type: 'bug_report',
+        kind: 'bug',
         title: 'create_item fails on large boards',
         description: 'When the board has more than 500 items, create_item returns a timeout error.',
         tool_name: 'create_item',
@@ -51,7 +51,7 @@ describe('SendFeedbackTool', () => {
     const tool = new SendFeedbackTool(mocks.mockApiClient);
 
     await tool.execute({
-      feedback_type: 'feedback',
+      kind: 'feedback',
       title: 'Great tool!',
       description: 'Really helpful for automation.',
     });
@@ -76,7 +76,7 @@ describe('SendFeedbackTool', () => {
     const tool = new SendFeedbackTool(mocks.mockApiClient, token);
 
     await tool.execute({
-      feedback_type: 'feature_request',
+      kind: 'feature_request',
       title: 'Support batch operations',
       description: 'Allow updating multiple items at once.',
     });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -39,7 +39,7 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
       '• The user tried to perform an action that the available MCP tools could not support and had to settle for a partial or manual solution\n' +
       '• You notice a recurring gap — something the user asked for that simply is not available\n\n' +
       'Set kind="bug" for failures and unexpected tool behavior, kind="feature_request" for capability gaps, kind="feedback" for general observations about usability or experience. ' +
-      'Optionally specify tool_name to associate the feedback with a specific MCP tool.\n\n' +
+      'Optionally specify tool_name to associate the feedback with a specific monday.com MCP tool.\n\n' +
       `IMPORTANT: ${PII_WARNING}`
     );
   }

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -16,7 +16,7 @@ export const sendFeedbackToolSchema = {
   tool_name: z
     .string()
     .optional()
-    .describe('The name of the MCP tool this feedback is about, if applicable (e.g. "create_item")'),
+    .describe('The name of the monday.com MCP tool this feedback is about, if applicable (e.g. "create_item", "get_board_info"). Only include monday.com MCP tool names — do not reference tools from other connected services.'),
 };
 
 export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolSchema> {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -26,7 +26,7 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
   type = ToolType.WRITE;
   annotations = createMondayApiAnnotations({
     title: 'Send Feedback',
-    readOnlyHint: false,
+    readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
   });
@@ -47,25 +47,33 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
   protected async executeInternal(
     input: ToolInputType<typeof sendFeedbackToolSchema>,
   ): Promise<ToolOutputType<never>> {
-    const token: string | undefined = (this.mondayApi as any).token;
-    const { aai, uid, actid, rgn, tid } = token
+    const apiClient = this.mondayApi;
+    const token = (apiClient as any)?.token;
+    const { aai, uid, actid, rgn } = token
       ? extractTokenInfo(token)
       : ({} as ReturnType<typeof extractTokenInfo>);
 
+    const agentType = this.context?.agentType;
+
     trackEvent({
       name: 'mcp_feedback_submitted',
+      kind: input.kind,
+      info1: input.title,
+      ...(agentType && { info2: agentType }),
+      ...(input.tool_name && { info3: input.tool_name }),
+      ...(actid !== undefined && { accountId: actid }),
+      ...(uid !== undefined && { userId: uid }),
       data: {
         kind: input.kind,
         title: input.title,
         description: input.description,
         ...(input.tool_name && { tool_name: input.tool_name }),
-        ...(this.context?.agentType && { agent_type: this.context.agentType }),
+        ...(agentType && { agent_type: agentType }),
         ...(this.context?.agentClientName && { agent_client_name: this.context.agentClientName }),
         ...(actid !== undefined && { account_id: actid }),
         ...(uid !== undefined && { user_id: uid }),
         ...(aai !== undefined && { api_app_id: aai }),
         ...(rgn !== undefined && { region: rgn }),
-        ...(tid !== undefined && { team_id: tid }),
       },
     });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod';
 import { ToolInputType, ToolOutputType, ToolType } from '../../../tool';
 import { BaseMondayApiTool, createMondayApiAnnotations } from '../base-monday-api-tool';
-import { trackEvent } from '../../../../utils/tracking.utils';
-import { extractTokenInfo } from '../../../../utils/token.utils';
 
 const PII_WARNING =
   'Do NOT include any personally identifiable information (PII) such as names, email addresses, phone numbers, or any other personal data.';
@@ -47,35 +45,13 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
   protected async executeInternal(
     input: ToolInputType<typeof sendFeedbackToolSchema>,
   ): Promise<ToolOutputType<never>> {
-    const apiClient = this.mondayApi;
-    const token = (apiClient as any)?.token;
-    const { aai, uid, actid, rgn } = token
-      ? extractTokenInfo(token)
-      : ({} as ReturnType<typeof extractTokenInfo>);
-
-    const agentType = this.context?.agentType;
-
-    trackEvent({
-      name: 'mcp_feedback_submitted',
-      kind: input.kind,
-      info1: input.title,
-      ...(agentType && { info2: agentType }),
-      ...(input.tool_name && { info3: input.tool_name }),
-      ...(actid !== undefined && { accountId: actid }),
-      ...(uid !== undefined && { userId: uid }),
-      data: {
-        kind: input.kind,
-        title: input.title,
-        description: input.description,
-        ...(input.tool_name && { tool_name: input.tool_name }),
-        ...(agentType && { agent_type: agentType }),
-        ...(this.context?.agentClientName && { agent_client_name: this.context.agentClientName }),
-        ...(actid !== undefined && { account_id: actid }),
-        ...(uid !== undefined && { user_id: uid }),
-        ...(aai !== undefined && { api_app_id: aai }),
-        ...(rgn !== undefined && { region: rgn }),
-      },
-    });
+    this.sessionContext.metadata ??= {};
+    this.sessionContext.metadata.kind = input.kind;
+    this.sessionContext.metadata.title = input.title;
+    this.sessionContext.metadata.description = input.description;
+    if (input.tool_name) {
+      this.sessionContext.metadata.tool_name = input.tool_name;
+    }
 
     return {
       content: {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -1,7 +1,6 @@
 import { z } from 'zod';
-import { ApiClient } from '@mondaydotcomorg/api';
 import { ToolInputType, ToolOutputType, ToolType } from '../../../tool';
-import { BaseMondayApiTool, createMondayApiAnnotations, MondayApiToolContext } from '../base-monday-api-tool';
+import { BaseMondayApiTool, createMondayApiAnnotations } from '../base-monday-api-tool';
 import { trackEvent } from '../../../../utils/tracking.utils';
 import { extractTokenInfo } from '../../../../utils/token.utils';
 
@@ -15,9 +14,7 @@ export const sendFeedbackToolSchema = {
   title: z.string().describe(`A short summary of the feedback. ${PII_WARNING}`),
   description: z
     .string()
-    .describe(
-      `Full details — what happened, what was expected, or what is being requested. ${PII_WARNING}`,
-    ),
+    .describe(`Full details — what happened, what was expected, or what is being requested. ${PII_WARNING}`),
   tool_name: z
     .string()
     .optional()
@@ -33,22 +30,6 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
     destructiveHint: false,
     idempotentHint: true,
   });
-
-  private readonly _apiToken?: string | (() => string);
-
-  constructor(
-    mondayApi: ApiClient | (() => ApiClient),
-    apiToken?: string | (() => string),
-    context?: MondayApiToolContext,
-  ) {
-    super(mondayApi, context);
-    this._apiToken = apiToken;
-  }
-
-  private get resolvedToken(): string | undefined {
-    if (!this._apiToken) return undefined;
-    return typeof this._apiToken === 'function' ? this._apiToken() : this._apiToken;
-  }
 
   getDescription(): string {
     return (
@@ -66,7 +47,10 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
   protected async executeInternal(
     input: ToolInputType<typeof sendFeedbackToolSchema>,
   ): Promise<ToolOutputType<never>> {
-    const { aai, uid, actid, rgn, tid } = this.resolvedToken ? extractTokenInfo(this.resolvedToken) : ({} as ReturnType<typeof extractTokenInfo>);
+    const token: string | undefined = (this.mondayApi as any).token;
+    const { aai, uid, actid, rgn, tid } = token
+      ? extractTokenInfo(token)
+      : ({} as ReturnType<typeof extractTokenInfo>);
 
     trackEvent({
       name: 'mcp_feedback_submitted',

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -5,12 +5,19 @@ import { BaseMondayApiTool, createMondayApiAnnotations, MondayApiToolContext } f
 import { trackEvent } from '../../../../utils/tracking.utils';
 import { extractTokenInfo } from '../../../../utils/token.utils';
 
+const PII_WARNING =
+  'Do NOT include any personally identifiable information (PII) such as names, email addresses, phone numbers, or any other personal data.';
+
 export const sendFeedbackToolSchema = {
-  feedback_type: z
-    .enum(['feedback', 'feature_request', 'bug_report'])
-    .describe('The type of submission: general feedback, a feature request, or a bug report'),
-  title: z.string().describe('A short summary of the feedback'),
-  description: z.string().describe('Full details — what happened, what was expected, or what is being requested'),
+  kind: z
+    .enum(['feedback', 'feature_request', 'bug'])
+    .describe('The kind of submission: general feedback, a feature request, or a bug report'),
+  title: z.string().describe(`A short summary of the feedback. ${PII_WARNING}`),
+  description: z
+    .string()
+    .describe(
+      `Full details — what happened, what was expected, or what is being requested. ${PII_WARNING}`,
+    ),
   tool_name: z
     .string()
     .optional()
@@ -47,7 +54,8 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
     return (
       'Submit feedback, a feature request, or a bug report about the monday.com MCP server. ' +
       'Use this when a user or agent wants to report an issue, suggest an improvement, or flag unexpected behavior. ' +
-      'Optionally specify tool_name to associate the feedback with a specific MCP tool.'
+      'Optionally specify tool_name to associate the feedback with a specific MCP tool. ' +
+      `IMPORTANT: ${PII_WARNING}`
     );
   }
 
@@ -63,7 +71,7 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
     trackEvent({
       name: 'mcp_feedback_submitted',
       data: {
-        feedback_type: input.feedback_type,
+        kind: input.kind,
         title: input.title,
         description: input.description,
         ...(input.tool_name && { tool_name: input.tool_name }),

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -66,7 +66,7 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
   protected async executeInternal(
     input: ToolInputType<typeof sendFeedbackToolSchema>,
   ): Promise<ToolOutputType<never>> {
-    const tokenInfo = this.resolvedToken ? extractTokenInfo(this.resolvedToken) : {};
+    const { aai, uid, actid, rgn, tid } = this.resolvedToken ? extractTokenInfo(this.resolvedToken) : ({} as ReturnType<typeof extractTokenInfo>);
 
     trackEvent({
       name: 'mcp_feedback_submitted',
@@ -77,7 +77,11 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
         ...(input.tool_name && { tool_name: input.tool_name }),
         ...(this.context?.agentType && { agent_type: this.context.agentType }),
         ...(this.context?.agentClientName && { agent_client_name: this.context.agentClientName }),
-        ...tokenInfo,
+        ...(actid !== undefined && { account_id: actid }),
+        ...(uid !== undefined && { user_id: uid }),
+        ...(aai !== undefined && { api_app_id: aai }),
+        ...(rgn !== undefined && { region: rgn }),
+        ...(tid !== undefined && { team_id: tid }),
       },
     });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -31,9 +31,14 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
 
   getDescription(): string {
     return (
-      'Submit feedback, a feature request, or a bug report about the monday.com MCP server. ' +
-      'Use this when a user or agent wants to report an issue, suggest an improvement, or flag unexpected behavior. ' +
-      'Optionally specify tool_name to associate the feedback with a specific MCP tool. ' +
+      'Submit feedback, feature requests, or bug reports about the monday.com MCP server to help improve it.\n\n' +
+      'Call this tool proactively — do NOT wait for the user to explicitly ask. Use it whenever you detect any of the following:\n' +
+      '• The user shows repeated signs of frustration: multiple corrections, restarting the same request several times, phrases like "that\'s wrong again", "why isn\'t this working"\n' +
+      '• You had to retry a task multiple times, go through an unusually long reasoning chain, or make many attempts to complete what should have been a simple request\n' +
+      '• A tool produced unexpected errors, empty results, or behaved in a way that required a workaround\n' +
+      '• The user tried to perform an action that the available MCP tools could not support and had to settle for a partial or manual solution\n' +
+      '• You notice a recurring gap — something the user asked for that simply is not available\n\n' +
+      'Set kind="bug" for failures and unexpected tool behavior, kind="feature_request" for capability gaps, kind="feedback" for general observations about usability or experience.\n\n' +
       `IMPORTANT: ${PII_WARNING}`
     );
   }

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod';
+import { ApiClient } from '@mondaydotcomorg/api';
+import { ToolInputType, ToolOutputType, ToolType } from '../../../tool';
+import { BaseMondayApiTool, createMondayApiAnnotations, MondayApiToolContext } from '../base-monday-api-tool';
+import { trackEvent } from '../../../../utils/tracking.utils';
+import { extractTokenInfo } from '../../../../utils/token.utils';
+
+export const sendFeedbackToolSchema = {
+  feedback_type: z
+    .enum(['feedback', 'feature_request', 'bug_report'])
+    .describe('The type of submission: general feedback, a feature request, or a bug report'),
+  title: z.string().describe('A short summary of the feedback'),
+  description: z.string().describe('Full details — what happened, what was expected, or what is being requested'),
+  tool_name: z
+    .string()
+    .optional()
+    .describe('The name of the MCP tool this feedback is about, if applicable (e.g. "create_item")'),
+};
+
+export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolSchema> {
+  name = 'send_feedback';
+  type = ToolType.WRITE;
+  annotations = createMondayApiAnnotations({
+    title: 'Send Feedback',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+  });
+
+  private readonly _apiToken?: string | (() => string);
+
+  constructor(
+    mondayApi: ApiClient | (() => ApiClient),
+    apiToken?: string | (() => string),
+    context?: MondayApiToolContext,
+  ) {
+    super(mondayApi, context);
+    this._apiToken = apiToken;
+  }
+
+  private get resolvedToken(): string | undefined {
+    if (!this._apiToken) return undefined;
+    return typeof this._apiToken === 'function' ? this._apiToken() : this._apiToken;
+  }
+
+  getDescription(): string {
+    return (
+      'Submit feedback, a feature request, or a bug report about the monday.com MCP server. ' +
+      'Use this when a user or agent wants to report an issue, suggest an improvement, or flag unexpected behavior. ' +
+      'Optionally specify tool_name to associate the feedback with a specific MCP tool.'
+    );
+  }
+
+  getInputSchema(): typeof sendFeedbackToolSchema {
+    return sendFeedbackToolSchema;
+  }
+
+  protected async executeInternal(
+    input: ToolInputType<typeof sendFeedbackToolSchema>,
+  ): Promise<ToolOutputType<never>> {
+    const tokenInfo = this.resolvedToken ? extractTokenInfo(this.resolvedToken) : {};
+
+    trackEvent({
+      name: 'mcp_feedback_submitted',
+      data: {
+        feedback_type: input.feedback_type,
+        title: input.title,
+        description: input.description,
+        ...(input.tool_name && { tool_name: input.tool_name }),
+        ...(this.context?.agentType && { agent_type: this.context.agentType }),
+        ...(this.context?.agentClientName && { agent_client_name: this.context.agentClientName }),
+        ...tokenInfo,
+      },
+    });
+
+    return {
+      content: {
+        message: 'Feedback submitted successfully. Thank you for helping improve the monday.com MCP server.',
+      },
+    };
+  }
+}

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -38,7 +38,8 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
       '• A tool produced unexpected errors, empty results, or behaved in a way that required a workaround\n' +
       '• The user tried to perform an action that the available MCP tools could not support and had to settle for a partial or manual solution\n' +
       '• You notice a recurring gap — something the user asked for that simply is not available\n\n' +
-      'Set kind="bug" for failures and unexpected tool behavior, kind="feature_request" for capability gaps, kind="feedback" for general observations about usability or experience.\n\n' +
+      'Set kind="bug" for failures and unexpected tool behavior, kind="feature_request" for capability gaps, kind="feedback" for general observations about usability or experience. ' +
+      'Optionally specify tool_name to associate the feedback with a specific MCP tool.\n\n' +
       `IMPORTANT: ${PII_WARNING}`
     );
   }

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -23,7 +23,7 @@ export const sendFeedbackToolSchema = {
 
 export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolSchema> {
   name = 'send_feedback';
-  type = ToolType.WRITE;
+  type = ToolType.READ;
   annotations = createMondayApiAnnotations({
     title: 'Send Feedback',
     readOnlyHint: true,

--- a/packages/agent-toolkit/src/utils/tracking.utils.ts
+++ b/packages/agent-toolkit/src/utils/tracking.utils.ts
@@ -1,38 +1,17 @@
 import axios from 'axios';
 
-export type TrackEventParams = {
-  name: string;
-  data: Record<string, unknown>;
-  kind?: string;
-  info1?: string;
-  info2?: string;
-  info3?: string;
-  accountId?: number;
-  userId?: number;
-};
-
 /**
  * Tracks event
  * @param name - Event name
  * @param data - Event data
- * @param kind - Optional event kind (top-level field)
- * @param info1 - Optional info field (top-level field)
- * @param info2 - Optional info field (top-level field)
- * @param info3 - Optional info field (top-level field)
  */
-export const trackEvent = ({ name, data, kind, info1, info2, info3, accountId, userId }: TrackEventParams): void => {
+export const trackEvent = ({ name, data }: { name: string; data: Record<string, unknown> }): void => {
   axios
     .post(
       'https://track.bigbrain.me/prod/event',
       {
         name,
         data,
-        ...(kind !== undefined && { kind }),
-        ...(info1 !== undefined && { info1 }),
-        ...(info2 !== undefined && { info2 }),
-        ...(info3 !== undefined && { info3 }),
-        ...(accountId !== undefined && { pulse_account_id: accountId }),
-        ...(userId !== undefined && { pulse_user_id: userId }),
       },
       {
         headers: {

--- a/packages/agent-toolkit/src/utils/tracking.utils.ts
+++ b/packages/agent-toolkit/src/utils/tracking.utils.ts
@@ -1,17 +1,38 @@
 import axios from 'axios';
 
+export type TrackEventParams = {
+  name: string;
+  data: Record<string, unknown>;
+  kind?: string;
+  info1?: string;
+  info2?: string;
+  info3?: string;
+  accountId?: number;
+  userId?: number;
+};
+
 /**
  * Tracks event
  * @param name - Event name
  * @param data - Event data
+ * @param kind - Optional event kind (top-level field)
+ * @param info1 - Optional info field (top-level field)
+ * @param info2 - Optional info field (top-level field)
+ * @param info3 - Optional info field (top-level field)
  */
-export const trackEvent = ({ name, data }: { name: string; data: Record<string, unknown> }): void => {
+export const trackEvent = ({ name, data, kind, info1, info2, info3, accountId, userId }: TrackEventParams): void => {
   axios
     .post(
       'https://track.bigbrain.me/prod/event',
       {
         name,
         data,
+        ...(kind !== undefined && { kind }),
+        ...(info1 !== undefined && { info1 }),
+        ...(info2 !== undefined && { info2 }),
+        ...(info3 !== undefined && { info3 }),
+        ...(accountId !== undefined && { pulse_account_id: accountId }),
+        ...(userId !== undefined && { pulse_user_id: userId }),
       },
       {
         headers: {


### PR DESCRIPTION
## Summary
- Adds a new `send_feedback` MCP tool that lets agents and users submit feedback, feature requests, or bug reports directly through the MCP server
- Submissions fire a `mcp_feedback_submitted` BigBrain event carrying the feedback payload plus account/user identity extracted from the JWT token
- Overrides the constructor in `SendFeedbackTool` to capture the API token (3rd arg already passed by `toolFactory`) without touching the base class or breaking existing tests

## Event schema
```
name: mcp_feedback_submitted
data:
  feedback_type:      'feedback' | 'feature_request' | 'bug_report'
  title:              string
  description:        string
  tool_name?:         string   // MCP tool the feedback is about
  agent_type?:        string
  agent_client_name?: string
  actid, uid, aai, tid, rgn    // from JWT token via extractTokenInfo
```

## Test plan
- [ ] 3 unit tests pass: full event payload, optional field omission, JWT token extraction
- [ ] `tsc --noEmit` clean

Closes https://monday.monday.com/boards/8222767873/pulses/12389774731