### PR TITLE
fix(agent-toolkit): actionable searchTerm validation and trim whitespace

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.56.1
+
+### search — actionable error and whitespace handling for searchTerm
+
+- `searchTerm` validation now returns an actionable message (`searchTerm must be a non-empty search string.`) instead of the generic Zod `String must contain at least 1 character(s)`, helping agents recover from empty-term calls
+- `searchTerm` is now trimmed before validation, so whitespace-only values (e.g. `"   "`) are correctly rejected and surrounding whitespace is stripped from valid terms before querying
+
 ## 5.54.1
 
 ### publish_workflow — restrict to explicit user request

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.56.0",
+  "version": "5.56.1",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
@@ -131,7 +131,38 @@ describe('SearchTool', () => {
       const result = await callToolByNameRawAsync('search', args);
 
       expect(result.content[0].text).toContain('Failed to execute tool search: Invalid arguments');
+      expect(result.content[0].text).toContain('searchTerm must be a non-empty search string.');
       expect(mocks.getMockRequest()).not.toHaveBeenCalled();
+    });
+
+    it('should reject whitespace-only searchTerm', async () => {
+      const args: Partial<inputType> = {
+        searchType: GlobalSearchType.BOARD,
+        searchTerm: '   ',
+      };
+
+      const result = await callToolByNameRawAsync('search', args);
+
+      expect(result.content[0].text).toContain('Failed to execute tool search: Invalid arguments');
+      expect(result.content[0].text).toContain('searchTerm must be a non-empty search string.');
+      expect(mocks.getMockRequest()).not.toHaveBeenCalled();
+    });
+
+    it('should trim surrounding whitespace from searchTerm before querying', async () => {
+      mocks.setResponse(mockDevBoardsResponse);
+
+      const args: inputType = {
+        searchType: GlobalSearchType.BOARD,
+        searchTerm: '  Test  ',
+      };
+
+      await callToolByNameAsync('search', args);
+
+      expect(mocks.getMockRequest()).toHaveBeenCalledWith(
+        expect.stringContaining('query SearchBoards'),
+        expect.objectContaining({ query: 'Test' }),
+        expect.anything(),
+      );
     });
 
     it('should clamp limit exceeding SEARCH_LIMIT (20) to 20', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.ts
@@ -33,7 +33,11 @@ import { SEARCH_TIMEOUT } from 'src/utils/time.utils';
 import { rethrowWithContext, throwIfSearchTimeoutError } from 'src/utils/error.utils';
 
 export const searchSchema = {
-  searchTerm: z.string().min(1).describe('The search term to use.'),
+  searchTerm: z
+    .string()
+    .trim()
+    .min(1, { message: 'searchTerm must be a non-empty search string.' })
+    .describe('The non-empty term to search for (at least one non-whitespace character).'),
   searchType: z
     .preprocess(
       (val) => (typeof val === 'string' ? (SEARCH_TYPE_ALIASES[val.toUpperCase()] ?? val.toUpperCase()) : val),


### PR DESCRIPTION
## What

Improves `searchTerm` validation on the `search` tool. MCP users frequently send empty (or whitespace-only) `searchTerm`, which failed with Zod's generic `String must contain at least 1 character(s)` message — not actionable, so agents couldn't recover.

## Changes

- **Actionable error:** empty `searchTerm` now returns `searchTerm must be a non-empty search string.` instead of the generic Zod message.
- **Whitespace handling:** `searchTerm` is now `.trim()`-ed before validation, so whitespace-only values (e.g. `"   "`) are correctly rejected (previously they passed `.min(1)` and hit the API with a useless query). Surrounding whitespace is also stripped from valid terms before querying.
- Updated field `.describe()` to state the non-empty requirement up front.
- Added tests: whitespace-only rejection, trimming behavior, and asserting the new message on empty input.

## Ticket

https://monday.monday.com/boards/8143454639/pulses/12476413389
