### PR TITLE
fix: resolve workforms ApiClient lazily to avoid expired tokens

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.56.1",
+  "version": "5.56.2",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/form-questions-editor-tool/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/form-questions-editor-tool/index.ts
@@ -13,7 +13,7 @@ export class FormQuestionsEditorTool extends BaseMondayApiTool<typeof formQuesti
     idempotentHint: false,
   });
 
-  private helpers = new FormQuestionsEditorToolHelpers(this.mondayApi);
+  private helpers = new FormQuestionsEditorToolHelpers(() => this.mondayApi);
 
   private readonly actionHandlers = new Map<
     FormQuestionActions,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/update-form-tool/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/update-form-tool/index.ts
@@ -13,7 +13,7 @@ export class UpdateFormTool extends BaseMondayApiTool<typeof updateFormToolSchem
     idempotentHint: true,
   });
 
-  private helpers = new UpdateFormToolHelpers(this.mondayApi);
+  private helpers = new UpdateFormToolHelpers(() => this.mondayApi);
 
   getDescription(): string {
     return 'Update a monday.com form. Use the action field to specify the operation.';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/form-questions-editor-tool-helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/form-questions-editor-tool-helpers.ts
@@ -14,10 +14,6 @@ import { formQuestionsEditorToolSchema } from '../form-questions-editor-tool/sch
 export class FormQuestionsEditorToolHelpers {
   constructor(private readonly getMondayApi: () => ApiClient) {}
 
-  private get mondayApi(): ApiClient {
-    return this.getMondayApi();
-  }
-
   async deleteQuestion(input: ToolInputType<typeof formQuestionsEditorToolSchema>): Promise<ToolOutputType<never>> {
     const questionId = input.questionId;
     if (!questionId) {
@@ -31,7 +27,7 @@ export class FormQuestionsEditorToolHelpers {
       questionId,
     };
 
-    await this.mondayApi.request<DeleteFormQuestionMutation>(deleteFormQuestion, deleteVariables);
+    await this.getMondayApi().request<DeleteFormQuestionMutation>(deleteFormQuestion, deleteVariables);
 
     return {
       content: { message: 'Question deleted', question_id: questionId, action_name: 'delete' },
@@ -59,7 +55,7 @@ export class FormQuestionsEditorToolHelpers {
       question,
     };
 
-    await this.mondayApi.request<UpdateFormQuestionMutation>(updateFormQuestion, updateVariables);
+    await this.getMondayApi().request<UpdateFormQuestionMutation>(updateFormQuestion, updateVariables);
 
     return {
       content: { message: 'Question updated', question_id: questionId, action_name: 'update' },
@@ -88,7 +84,7 @@ export class FormQuestionsEditorToolHelpers {
       },
     };
 
-    const result = await this.mondayApi.request<CreateFormQuestionMutation>(createFormQuestion, createVariables);
+    const result = await this.getMondayApi().request<CreateFormQuestionMutation>(createFormQuestion, createVariables);
 
     return {
       content: { message: 'Question created', question_id: result.create_form_question?.id, action_name: 'create' },

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/form-questions-editor-tool-helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/form-questions-editor-tool-helpers.ts
@@ -12,7 +12,14 @@ import { ApiClient } from '@mondaydotcomorg/api';
 import { formQuestionsEditorToolSchema } from '../form-questions-editor-tool/schema';
 
 export class FormQuestionsEditorToolHelpers {
-  constructor(private mondayApi: ApiClient) {}
+  // Resolve the ApiClient lazily on every call. The tool's `mondayApi` getter mints a fresh
+  // client (with a freshly-signed, short-lived token) on each access; capturing the resolved
+  // client at construction would freeze a token that expires before the tool is invoked.
+  constructor(private readonly getMondayApi: () => ApiClient) {}
+
+  private get mondayApi(): ApiClient {
+    return this.getMondayApi();
+  }
 
   async deleteQuestion(input: ToolInputType<typeof formQuestionsEditorToolSchema>): Promise<ToolOutputType<never>> {
     const questionId = input.questionId;

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/form-questions-editor-tool-helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/form-questions-editor-tool-helpers.ts
@@ -12,9 +12,6 @@ import { ApiClient } from '@mondaydotcomorg/api';
 import { formQuestionsEditorToolSchema } from '../form-questions-editor-tool/schema';
 
 export class FormQuestionsEditorToolHelpers {
-  // Resolve the ApiClient lazily on every call. The tool's `mondayApi` getter mints a fresh
-  // client (with a freshly-signed, short-lived token) on each access; capturing the resolved
-  // client at construction would freeze a token that expires before the tool is invoked.
   constructor(private readonly getMondayApi: () => ApiClient) {}
 
   private get mondayApi(): ApiClient {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/update-form-tool-helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/update-form-tool-helpers.ts
@@ -44,7 +44,14 @@ import { ApiClient } from '@mondaydotcomorg/api';
 import { updateFormToolSchema } from '../update-form-tool/schema';
 
 export class UpdateFormToolHelpers {
-  constructor(private mondayApi: ApiClient) {}
+  // Resolve the ApiClient lazily on every call. The tool's `mondayApi` getter mints a fresh
+  // client (with a freshly-signed, short-lived token) on each access; capturing the resolved
+  // client at construction would freeze a token that expires before the tool is invoked.
+  constructor(private readonly getMondayApi: () => ApiClient) {}
+
+  private get mondayApi(): ApiClient {
+    return this.getMondayApi();
+  }
 
   async setFormPassword(input: ToolInputType<typeof updateFormToolSchema>): Promise<ToolOutputType<never>> {
     if (!input.formPassword) {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/update-form-tool-helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/update-form-tool-helpers.ts
@@ -44,9 +44,6 @@ import { ApiClient } from '@mondaydotcomorg/api';
 import { updateFormToolSchema } from '../update-form-tool/schema';
 
 export class UpdateFormToolHelpers {
-  // Resolve the ApiClient lazily on every call. The tool's `mondayApi` getter mints a fresh
-  // client (with a freshly-signed, short-lived token) on each access; capturing the resolved
-  // client at construction would freeze a token that expires before the tool is invoked.
   constructor(private readonly getMondayApi: () => ApiClient) {}
 
   private get mondayApi(): ApiClient {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/update-form-tool-helpers.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/workforms-tools/utils/update-form-tool-helpers.ts
@@ -46,10 +46,6 @@ import { updateFormToolSchema } from '../update-form-tool/schema';
 export class UpdateFormToolHelpers {
   constructor(private readonly getMondayApi: () => ApiClient) {}
 
-  private get mondayApi(): ApiClient {
-    return this.getMondayApi();
-  }
-
   async setFormPassword(input: ToolInputType<typeof updateFormToolSchema>): Promise<ToolOutputType<never>> {
     if (!input.formPassword) {
       return {
@@ -64,7 +60,7 @@ export class UpdateFormToolHelpers {
       },
     };
 
-    await this.mondayApi.request<SetFormPasswordMutation>(setFormPassword, variables);
+    await this.getMondayApi().request<SetFormPasswordMutation>(setFormPassword, variables);
 
     return {
       content: {
@@ -80,7 +76,7 @@ export class UpdateFormToolHelpers {
       formToken: input.formToken,
     };
 
-    await this.mondayApi.request<ShortenFormUrlMutation>(shortenFormUrl, variables);
+    await this.getMondayApi().request<ShortenFormUrlMutation>(shortenFormUrl, variables);
 
     return {
       content: {
@@ -96,7 +92,7 @@ export class UpdateFormToolHelpers {
       formToken: input.formToken,
     };
 
-    await this.mondayApi.request<DeactivateFormMutation>(deactivateForm, variables);
+    await this.getMondayApi().request<DeactivateFormMutation>(deactivateForm, variables);
 
     return {
       content: { message: 'Form successfully deactivated', form_token: input.formToken, action_name: 'deactivateForm' },
@@ -108,7 +104,7 @@ export class UpdateFormToolHelpers {
       formToken: input.formToken,
     };
 
-    await this.mondayApi.request<ActivateFormMutation>(activateForm, variables);
+    await this.getMondayApi().request<ActivateFormMutation>(activateForm, variables);
 
     return {
       content: { message: 'Form successfully activated', form_token: input.formToken, action_name: 'activateForm' },
@@ -135,7 +131,7 @@ export class UpdateFormToolHelpers {
       },
     };
 
-    const res = await this.mondayApi.request<CreateFormTagMutation>(createFormTag, variables);
+    const res = await this.getMondayApi().request<CreateFormTagMutation>(createFormTag, variables);
 
     return {
       content: {
@@ -165,7 +161,7 @@ export class UpdateFormToolHelpers {
       tagId: input.tag.id,
     };
 
-    await this.mondayApi.request<DeleteFormTagMutation>(deleteFormTag, variables);
+    await this.getMondayApi().request<DeleteFormTagMutation>(deleteFormTag, variables);
 
     return {
       content: { message: 'Tag deleted', form_token: input.formToken, tag_id: input.tag.id, action_name: 'deleteTag' },
@@ -184,7 +180,7 @@ export class UpdateFormToolHelpers {
       appearance: input.form.appearance as FormAppearanceInput,
     };
 
-    const res = await this.mondayApi.request<UpdateFormAppearanceMutation>(updateFormAppearance, variables);
+    const res = await this.getMondayApi().request<UpdateFormAppearanceMutation>(updateFormAppearance, variables);
 
     return {
       content: {
@@ -208,7 +204,7 @@ export class UpdateFormToolHelpers {
       accessibility: input.form.accessibility as FormAccessibilityInput,
     };
 
-    const res = await this.mondayApi.request<UpdateFormAccessibilityMutation>(updateFormAccessibility, variables);
+    const res = await this.getMondayApi().request<UpdateFormAccessibilityMutation>(updateFormAccessibility, variables);
 
     return {
       content: {
@@ -235,7 +231,7 @@ export class UpdateFormToolHelpers {
       is_anonymous,
     };
 
-    const res = await this.mondayApi.request<UpdateFormFeaturesMutation>(updateFormFeatures, variables);
+    const res = await this.getMondayApi().request<UpdateFormFeaturesMutation>(updateFormFeatures, variables);
 
     return {
       content: {
@@ -260,7 +256,7 @@ export class UpdateFormToolHelpers {
       questions: input.form.questions as QuestionOrderInput[],
     };
 
-    const res = await this.mondayApi.request<UpdateFormQuestionOrderMutation>(updateFormQuestionOrder, variables);
+    const res = await this.getMondayApi().request<UpdateFormQuestionOrderMutation>(updateFormQuestionOrder, variables);
 
     return {
       content: {
@@ -285,7 +281,7 @@ export class UpdateFormToolHelpers {
       description: input.form.description,
     };
 
-    const res = await this.mondayApi.request<UpdateFormHeaderMutation>(updateFormHeader, variables);
+    const res = await this.getMondayApi().request<UpdateFormHeaderMutation>(updateFormHeader, variables);
 
     return {
       content: {


### PR DESCRIPTION
The update_form and form_questions_editor tools instantiated their helpers in class field initializers (private helpers = new X(this.mondayApi)), which resolve mondayApi once at construction. When the client is supplied as a () => ApiClient provider that mints freshly-signed, short-lived tokens, the captured client's token could expire before the tool actually runs.

The helpers now receive a () => ApiClient provider and resolve the client lazily on each call, matching the ApiClient | (() => ApiClient) idiom already used by BaseMondayApiTool.

Changed FormQuestionsEditorToolHelpers / UpdateFormToolHelpers constructors to take () => ApiClient, resolving via a private getter per call