### PR TITLE
fix(agent-toolkit): scope send_feedback tool strictly to monday.com MCP

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.59.0",
+  "version": "5.59.1",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/send-feedback-tool/send-feedback-tool.ts
@@ -40,7 +40,9 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
       '• You notice a recurring gap — something the user asked for that simply is not available\n\n' +
       'Set kind="bug" for failures and unexpected tool behavior, kind="feature_request" for capability gaps, kind="feedback" for general observations about usability or experience. ' +
       'Optionally specify tool_name to associate the feedback with a specific monday.com MCP tool.\n\n' +
-      `IMPORTANT: ${PII_WARNING}`
+      'IMPORTANT: This tool is strictly for feedback about monday.com MCP tools and monday.com functionality only. ' +
+      'Do NOT call it for issues with other connectors or services (e.g. Google Drive, Slack, GitHub, or any non-monday.com integration). ' +
+      `${PII_WARNING}`
     );
   }
 


### PR DESCRIPTION
## Summary
- Adds an explicit `IMPORTANT` constraint to the `send_feedback` tool description making it clear the tool is strictly for monday.com MCP tools and functionality only
- Explicitly lists non-monday.com connectors (Google Drive, Slack, GitHub) as examples of what should **not** trigger the tool
- Bumps `@mondaydotcomorg/agent-toolkit` patch version to `5.57.1`

## Problem
The tool was receiving feedback about third-party connectors (e.g. Google Drive) because the description lacked a clear scope boundary — AI agents would call it whenever they detected frustration or tool failures, regardless of which connector was involved.

## Test plan
- [ ] Verify `send_feedback` tool description includes the new `IMPORTANT` scope restriction
- [ ] Confirm the tool is not called when a user reports issues with a non-monday.com integration

🤖 Generated with [Claude Code](https://claude.com/claude-code)