### PR TITLE
chore(agent-toolkit): bump version to 5.61.2

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.61.1",
+  "version": "5.61.2",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
Bumps version from 5.61.1 to 5.61.2 to release the `get_monday_knowledge` tool (merged in #429).