### PR TITLE
fix(agent-toolkit): clarify searchTerm and give actionable missing-searchTerm error

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.61.4
+
+### search — clearer searchTerm guidance and an actionable missing-searchTerm error
+
+- Strengthened the tool description and the `searchTerm` field description to define `searchTerm` as the phrase the search matches against (the text/keywords to look for), state that it is required and non-empty, and clarify it is not a filter or an id. Directly targets the largest residual validation-error bucket: callers omitting the term or sending the wrong field
+- A missing `searchTerm` now returns an actionable, browse-oriented message pointing callers at `workspace_info` (boards/docs/folders) and `get_board_items_page` (items) instead of the generic "Required", so callers trying to list rather than search can self-correct. An empty/whitespace `searchTerm` keeps its existing non-empty message
+- Both the description and the error name the browse alternatives, so a caller with browse intent (no search phrase) is steered to the right tool
+
 ## 5.61.3
 
 ### search — propagate location ids (board/workspace/item) across entities

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.61.3",
+  "version": "5.61.4",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.consts.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.consts.ts
@@ -7,6 +7,18 @@ export const MAX_FOLDERS_LIMIT = 100;
 export const SUPPORTED_SEARCH_TYPES_TEXT = Object.values(GlobalSearchType).join(', ');
 
 /**
+ * Actionable message for a missing/empty searchTerm. The tool has no "list
+ * everything" mode, so callers that omit the term (or send an empty one) are
+ * almost always trying to browse — point them at the tools that do that instead
+ * of re-failing the same empty search. Reused by the schema description and the
+ * runtime validation error so the guidance is identical in both places.
+ */
+export const MISSING_SEARCH_TERM_TEXT =
+  'searchTerm is required and must be a non-empty search string. ' +
+  'To browse or list without a search term, use workspace_info (for boards, docs, and folders in a workspace) ' +
+  'or get_board_items_page (for items within a specific board).';
+
+/**
  * Canonicalize a raw searchType string so aliases and redirects match regardless
  * of case or separators (e.g. "board-item" and "board items" both normalize to
  * "BOARD_ITEM"). Only whitespace/hyphen/slash separators are collapsed — other

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.test.ts
@@ -100,6 +100,18 @@ describe('SearchTool', () => {
       );
       expect(description).not.toContain('IMPORTANT: ids returned by this tool are prefixed');
     });
+
+    it('should explain that searchTerm is the phrase to match, required and non-empty, with a browse alternative', async () => {
+      const tool = new SearchTool(mocks.mockApiClient);
+      const description = tool.getDescription();
+
+      // The description must define searchTerm as the phrase the search matches
+      // against, and steer the model away from empty/absent searchTerm calls
+      // (the single largest source of validation failures).
+      expect(description).toContain('searchTerm is the phrase');
+      expect(description).toMatch(/required and must be non-empty/i);
+      expect(description).toContain('workspace_info');
+    });
   });
 
   describe('Schema Validation', () => {
@@ -116,7 +128,7 @@ describe('SearchTool', () => {
       expect(mocks.getMockRequest()).not.toHaveBeenCalled();
     });
 
-    it('should reject missing searchTerm for BOARD search', async () => {
+    it('should reject missing searchTerm for BOARD search with an actionable, browse-oriented message', async () => {
       const args: Partial<inputType> = {
         searchType: GlobalSearchType.BOARD,
         // searchTerm is missing
@@ -124,21 +136,24 @@ describe('SearchTool', () => {
 
       const result = await callToolByNameRawAsync('search', args);
 
-      expect(result.content[0].text).toContain('Failed to execute tool search: Invalid arguments');
-      expect(result.content[0].text).toContain('searchTerm');
-      expect(result.content[0].text).toContain('Required');
+      expect(result.content[0].text).toContain('Failed to execute tool search');
+      expect(result.content[0].text).toContain('searchTerm is required');
+      // Points the caller at the right tool to browse/list without a term,
+      // so it can self-correct instead of retrying the same empty search.
+      expect(result.content[0].text).toContain('workspace_info');
+      expect(result.content[0].text).toContain('get_board_items_page');
       expect(mocks.getMockRequest()).not.toHaveBeenCalled();
     });
 
-    it('should reject missing searchTerm for DOCUMENTS search', async () => {
+    it('should reject missing searchTerm for DOCUMENTS search with an actionable message', async () => {
       const args: Partial<inputType> = {
         searchType: GlobalSearchType.DOCUMENTS,
       };
 
       const result = await callToolByNameRawAsync('search', args);
 
-      expect(result.content[0].text).toContain('Failed to execute tool search: Invalid arguments');
-      expect(result.content[0].text).toContain('searchTerm');
+      expect(result.content[0].text).toContain('Failed to execute tool search');
+      expect(result.content[0].text).toContain('searchTerm is required');
       expect(mocks.getMockRequest()).not.toHaveBeenCalled();
     });
 
@@ -283,6 +298,20 @@ describe('SearchTool', () => {
       expect(result.content[0].text).not.toContain('BOARD_ITEM');
       // The redirect still fires because the lookup re-normalizes the raw value.
       expect(result.content[0].text).toContain('get_board_items_page');
+      expect(mocks.getMockRequest()).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('query key is not an accepted alias for searchTerm', () => {
+    it('should reject a call that sends only `query` (unknown field) with the actionable missing-searchTerm message', async () => {
+      const args = {
+        searchType: GlobalSearchType.BOARD,
+        query: 'IT-439',
+      } as any;
+
+      const result = await callToolByNameRawAsync('search', args);
+
+      expect(result.content[0].text).toContain('searchTerm is required');
       expect(mocks.getMockRequest()).not.toHaveBeenCalled();
     });
   });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/search-tool/search-tool.ts
@@ -35,6 +35,7 @@ import { normalizeString } from 'src/utils/string.utils';
 import { GlobalSearchType, SearchResult } from './search-tool.types';
 import {
   MAX_FOLDERS_LIMIT,
+  MISSING_SEARCH_TERM_TEXT,
   SEARCH_LIMIT,
   SEARCH_TYPE_ALIASES,
   SEARCH_TYPE_REDIRECTS,
@@ -42,7 +43,12 @@ import {
   normalizeSearchType,
 } from './search-tool.consts';
 import { SEARCH_TIMEOUT } from 'src/utils/time.utils';
-import { throwIfSearchTimeoutError, ToolValidationError, TOOL_EXECUTION_FAILED_CODE } from 'src/utils/error.utils';
+import {
+  throwIfSearchTimeoutError,
+  ToolValidationError,
+  TOOL_EXECUTION_FAILED_CODE,
+  MISSING_REQUIRED_PARAMETER_CODE,
+} from 'src/utils/error.utils';
 
 const SUPPORTED_SEARCH_TYPES = new Set<string>(Object.values(GlobalSearchType));
 
@@ -156,11 +162,20 @@ const limitSchema: z.ZodType<number, z.ZodTypeDef, unknown> = z
   .describe(`The number of items to get. Maximum is ${SEARCH_LIMIT}.`) as z.ZodType<number, z.ZodTypeDef, unknown>;
 
 export const searchSchema = {
+  // Optional at the schema level (rather than a required field) so a genuinely
+  // absent searchTerm is handled in executeInternal with the actionable,
+  // browse-oriented MISSING_SEARCH_TERM_TEXT instead of Zod's bare "Required".
+  // When searchTerm IS provided, .min(1) still rejects empty/whitespace with the
+  // original actionable message.
   searchTerm: z
     .string()
     .trim()
     .min(1, { message: 'searchTerm must be a non-empty search string.' })
-    .describe('The non-empty term to search for (at least one non-whitespace character).'),
+    .optional()
+    .describe(
+      'The search phrase — the text the search matches results against (e.g. a board name, item title, or keywords). ' +
+        'Required and must be non-empty. This is NOT a filter or an id — pass the words to look for.',
+    ),
   searchType: searchTypeSchema,
   limit: limitSchema,
 
@@ -192,6 +207,7 @@ export class SearchTool extends BaseMondayApiTool<SearchToolInput> {
 
   getDescription(): string {
     return `Search within monday.com platform. Supported searchType values: ${SUPPORTED_SEARCH_TYPES_TEXT}.
+searchTerm is the phrase the search matches against — the text/keywords to look for (e.g. a board name, item title, or a word from an update). It is required and must be non-empty. This tool has no "list everything" mode: to browse or list without a search phrase, use workspace_info (boards/docs/folders in a workspace) or get_board_items_page (items in a board) instead of calling search with an empty searchTerm.
 For searching/listing specific users and teams, use list_users_and_teams tool.
 For account-level info (plan, member count, products), use get_user_context tool.
 For browsing all boards, docs, or folders within a workspace without a search term, use workspace_info tool.
@@ -213,16 +229,24 @@ FOLDERS search returns id and title. Optionally scope it with workspaceIds, whic
   }
 
   protected async executeInternal(input: ToolInputType<SearchToolInput>): Promise<ToolOutputType<never>> {
+    // searchTerm is optional at the schema level so a missing term produces an
+    // actionable, browse-oriented error here rather than Zod's bare "Required".
+    // (An empty/whitespace term that IS present is already rejected by the schema.)
+    const { searchTerm } = input;
+    if (!searchTerm) {
+      throw new ToolValidationError(MISSING_SEARCH_TERM_TEXT, MISSING_REQUIRED_PARAMETER_CODE);
+    }
+
     try {
       if (input.searchType === GlobalSearchType.FOLDERS) {
-        const { results, truncated } = await this.searchFoldersAsync(input);
+        const { results, truncated } = await this.searchFoldersAsync(input, searchTerm);
         const message = truncated
           ? `Search results (truncated: only the first ${MAX_FOLDERS_LIMIT} folders across the searched workspaces were scanned. Narrow with workspaceIds for complete results.)`
           : 'Search results';
         return { content: { message, data: results } };
       }
 
-      const data = await this.runSmartSearchAsync(input);
+      const data = await this.runSmartSearchAsync(input, searchTerm);
       return { content: { message: 'Search results', data } };
     } catch (error) {
       throwIfSearchTimeoutError(error);
@@ -230,38 +254,41 @@ FOLDERS search returns id and title. Optionally scope it with workspaceIds, whic
     }
   }
 
-  private async runSmartSearchAsync(input: ToolInputType<SearchToolInput>): Promise<SearchResult[]> {
+  private async runSmartSearchAsync(
+    input: ToolInputType<SearchToolInput>,
+    searchTerm: string,
+  ): Promise<SearchResult[]> {
     const workspaceIds = toFilterIds(input.workspaceIds?.map((id) => id.toString()));
 
     if (input.searchType === GlobalSearchType.BOARD) {
-      return this.searchBoardsAsync(input.searchTerm, input.limit, workspaceIds);
+      return this.searchBoardsAsync(searchTerm, input.limit, workspaceIds);
     }
 
     if (input.searchType === GlobalSearchType.DOCUMENTS) {
-      return this.searchDocsAsync(input.searchTerm, input.limit, workspaceIds);
+      return this.searchDocsAsync(searchTerm, input.limit, workspaceIds);
     }
 
     if (input.searchType === GlobalSearchType.WORKSPACES) {
-      return this.searchWorkspacesAsync(input.searchTerm, input.limit);
+      return this.searchWorkspacesAsync(searchTerm, input.limit);
     }
 
     if (input.searchType === GlobalSearchType.UPDATES) {
       const boardIds = toFilterIds(input.boardIds?.map((id) => id.toString()));
       const creatorIds = toFilterIds(input.creatorIds?.map((id) => id.toString()));
-      return this.searchUpdatesAsync(input.searchTerm, input.limit, boardIds, creatorIds);
+      return this.searchUpdatesAsync(searchTerm, input.limit, boardIds, creatorIds);
     }
 
     if (input.searchType === GlobalSearchType.ITEMS) {
-      return this.searchItemsAsync(input.searchTerm, input.limit, workspaceIds);
+      return this.searchItemsAsync(searchTerm, input.limit, workspaceIds);
     }
 
     if (input.searchType === GlobalSearchType.TIMELINE_ITEMS) {
-      return this.searchTimelineItemsAsync(input.searchTerm, input.limit);
+      return this.searchTimelineItemsAsync(searchTerm, input.limit);
     }
 
     if (input.searchType === GlobalSearchType.DASHBOARDS) {
       const creatorIds = input.creatorIds?.map((id) => id.toString());
-      return this.searchOverviewsAsync(input.searchTerm, input.limit, workspaceIds, creatorIds);
+      return this.searchOverviewsAsync(searchTerm, input.limit, workspaceIds, creatorIds);
     }
 
     throw new ToolValidationError(
@@ -390,8 +417,9 @@ FOLDERS search returns id and title. Optionally scope it with workspaceIds, whic
 
   private async searchFoldersAsync(
     input: ToolInputType<SearchToolInput>,
+    searchTerm: string,
   ): Promise<{ results: SearchResult[]; truncated: boolean }> {
-    const normalizedSearchTerm = normalizeString(input.searchTerm);
+    const normalizedSearchTerm = normalizeString(searchTerm);
     // A searchTerm made only of characters normalizeString strips (e.g. "###" or
     // emoji) would otherwise normalize to '', and every string includes(''),
     // turning the filter below into a no-op that returns unrelated folders.


### PR DESCRIPTION
## Summary

Reduces the largest **residual** validation-error bucket for the `search` tool, identified from a week of production `platform-mcp-gateway` logs. Two changes, both localized to the search tool and both about making the `searchTerm` contract obvious:

1. **Clarify `searchTerm` in the tool description and the field description** — define it as the phrase the search matches against (the text/keywords to look for), state it is required and non-empty, and note it is not a filter or an id.
2. **Return an actionable, browse-oriented error when `searchTerm` is missing**, pointing callers at the tools that browse/list without a search phrase.

> Note: an earlier revision of this PR added a `query` alias for `searchTerm`. That was intentionally dropped — a second name for the same concept muddies the schema. The fix is to make the single `searchTerm` field self-explanatory instead.

## Rationale (from production data)

Over the past week (Jul 17–23), the `search` tool logged **10,281 errors**, of which **8,431 (82%) were client-side input-validation failures** — not backend faults. Categorized:

| Cause | Vol/wk | What the model actually sent |
|---|--:|---|
| **Missing `searchTerm`** (incl. wrong field / browse intent) | **~6,330** | `{"searchType":"boards"}`, `{"searchType":"board","limit":100}`, `{}`, `{"query":"IT-439"}` |
| Empty `searchTerm` | 1,116 | `{"searchTerm":"","searchType":"ITEMS"}` |
| Invalid `searchType` | 779 | `form`, `user`, `all` (largely already redirected) |
| Missing `searchType` | 206 | `{"searchTerm":"x"}` (already actionable) |

The tool was already hardened for `searchType` normalization, redirects, and empty-term messaging (#406, #414, #424, #427). These are the errors that *survived* those mitigations, and they concentrate in callers that never supply a valid search phrase — either omitting it, sending a different field (e.g. `query`), or trying to browse/list (which `search` does not do).

Root causes and how each change addresses them:

- **Wrong field / unclear contract.** Of the "searchTerm Required" errors, ~2,675/wk actually carried a `query` key, and thousands more sent only `searchType`. The model didn't know `searchTerm` is the mandatory phrase to match on. **Fix 1** states this plainly in both the tool description and the field `.describe()`, so the model supplies it in the first place rather than guessing at a field name.
- **Browse intent.** The `{"searchType":"boards"}`-style calls (~3,774/wk) and empty-string calls (1,116/wk) are the model trying to browse/list, which `search` doesn't support. Previously a missing term returned Zod's bare `Required`. **Fix 2** returns a message that names the right tools (`workspace_info`, `get_board_items_page`), mirroring the existing `SEARCH_TYPE_REDIRECTS` self-correction pattern.

## Changes

- `getDescription()` and the `searchTerm` field `.describe()`: define `searchTerm` as the search phrase, required and non-empty, not a filter/id.
- `searchSchema.searchTerm`: optional at the schema level so a genuinely absent term is handled in `executeInternal` with the actionable message rather than Zod's `Required`. A present-but-empty/whitespace term still gets the existing non-empty message via `.min(1)`.
- `executeInternal`: throws `ToolValidationError(MISSING_SEARCH_TERM_TEXT, MISSING_REQUIRED_PARAMETER_CODE)` (stable code for observability) when `searchTerm` is absent.
- New shared `MISSING_SEARCH_TERM_TEXT` constant reused by the runtime error (and aligned with the description) so guidance is consistent.

## Testing

- TDD: tests written and watched fail before implementing.
- `search-tool.test.ts`: 121 pass (updated the two missing-term tests to assert the new actionable message; added a description test and a test that a `query`-only call is rejected with the missing-searchTerm guidance).
- Full `agent-toolkit` suite: **1,343 pass**. Lint clean, build succeeds. (The repo's tool-description-safety guard, which rejects `;`/backtick in descriptions, is respected.)

## Expected impact

- Fix 1 attacks the root of the ~6,330/wk missing-`searchTerm` bucket by making the required phrase unambiguous up front.
- Fix 2 gives browse-intent and empty-term calls a self-correcting path instead of an opaque `Required`.
- Remaining buckets (`form`/`user` intents, timeouts, rate-limiting) are intrinsic and out of scope here.
