### PR TITLE
fix(agent-toolkit): board_insights — coerce split `between` filters

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.61.7
+
+### board_insights — coerce `between` filters that split the range across compareValue + compareAttribute
+
+- `board_insights` shares `filterRulesSchema` with `get_board_items_page`, which exposes an optional `compareAttribute` for cross-column comparisons. The aggregate resolver behind `board_insights` doesn't support it — for `between` it needs the range as a two-element `compareValue` array.
+- Observed in production: agents produced `{operator: "between", compareValue: "<from>", compareAttribute: "<to>"}` and the resolver rejected the request with `{"operator":"BETWEEN__<to>","reason":"no_operator_config"}` (HTTP 400).
+- `handleFilters` in `board-insights-utils.ts` now detects that split shape and merges it back into `compareValue: [from, to]` before dispatch. Non-`between` rules and already-array `compareValue`s are untouched.
+
 ## 5.61.5
 
 ### update_doc — bulk-only delete via delete_blocks (breaking)

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.61.6",
+  "version": "5.61.7",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-tool.test.ts
@@ -111,6 +111,92 @@ describe('Board Insights Tool', () => {
         });
       });
 
+      it('should coerce a `between` rule that split its range across compareValue + compareAttribute into a two-element compareValue array', () => {
+        const input = {
+          boardId: 123,
+          filters: [
+            {
+              columnId: 'date',
+              compareValue: '2026-07-01',
+              compareAttribute: '2026-07-31',
+              operator: ItemsQueryRuleOperator.Between,
+            },
+          ],
+          filtersOperator: ItemsQueryOperator.And,
+        };
+
+        const result = handleFilters(input as any);
+
+        expect(result).toEqual({
+          rules: [
+            {
+              column_id: 'date',
+              compare_value: ['2026-07-01', '2026-07-31'],
+              operator: ItemsQueryRuleOperator.Between,
+              compare_attribute: undefined,
+            },
+          ],
+          operator: ItemsQueryOperator.And,
+        });
+      });
+
+      it('should leave a `between` rule with an already-array compareValue untouched', () => {
+        const input = {
+          boardId: 123,
+          filters: [
+            {
+              columnId: 'date',
+              compareValue: ['2026-07-01', '2026-09-30'],
+              operator: ItemsQueryRuleOperator.Between,
+            },
+          ],
+          filtersOperator: ItemsQueryOperator.And,
+        };
+
+        const result = handleFilters(input as any);
+
+        expect(result).toEqual({
+          rules: [
+            {
+              column_id: 'date',
+              compare_value: ['2026-07-01', '2026-09-30'],
+              operator: ItemsQueryRuleOperator.Between,
+              compare_attribute: undefined,
+            },
+          ],
+          operator: ItemsQueryOperator.And,
+        });
+      });
+
+      it('should not coerce non-`between` rules that also carry a compareAttribute', () => {
+        const input = {
+          boardId: 123,
+          filters: [
+            {
+              columnId: 'person',
+              compareValue: [1234],
+              compareAttribute: 'id',
+              operator: ItemsQueryRuleOperator.AnyOf,
+            },
+          ],
+          filtersOperator: ItemsQueryOperator.And,
+        };
+
+        const result = handleFilters(input as any);
+
+        expect(result).toEqual({
+          rules: [
+            {
+              column_id: 'person',
+              compare_value: [1234],
+              compare_attribute: 'id',
+              operator: ItemsQueryRuleOperator.AnyOf,
+            },
+          ],
+          operator: ItemsQueryOperator.And,
+        });
+      });
+
       it('should include orderBy when provided', () => {
         const input = {
           boardId: 123,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-utils.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/board-insights/board-insights-utils.ts
@@ -11,8 +11,42 @@ import {
   AggregateSelectFunctionName,
   ItemsQuery,
   ItemsQueryOrderBy,
+  ItemsQueryRuleOperator,
 } from 'src/monday-graphql/generated/graphql/graphql';
 import { transformativeFunctions } from './board-insights.consts';
+
+type BoardInsightsFilterRule = NonNullable<
+  ToolInputType<typeof boardInsightsToolSchema>['filters']
+>[number];
+
+function isScalar(value: unknown): value is string | number | boolean {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
+}
+
+/** The `filterRulesSchema` is shared with `get_board_items_page`, which
+ *  legitimately uses `compareAttribute` for cross-column comparisons. The
+ *  aggregate resolver behind `board_insights` does not — for `between` it
+ *  expects the range as a two-element `compareValue` array. LLMs seeing the
+ *  shared schema cargo-cult `compareAttribute` as the range end, producing:
+ *      { operator: "between", compareValue: "<from>", compareAttribute: "<to>" }
+ *  which the resolver rejects with `{"operator":"BETWEEN__<to>","reason":"no_operator_config"}`.
+ *  Coerce that shape back into `compareValue: [from, to]` before dispatch. */
+function normalizeBetweenRule(rule: BoardInsightsFilterRule): BoardInsightsFilterRule {
+  if (rule.operator !== ItemsQueryRuleOperator.Between) {
+    return rule;
+  }
+  if (Array.isArray(rule.compareValue)) {
+    return rule;
+  }
+  if (!isScalar(rule.compareValue) || !isScalar(rule.compareAttribute)) {
+    return rule;
+  }
+  return {
+    ...rule,
+    compareValue: [String(rule.compareValue), String(rule.compareAttribute)],
+    compareAttribute: undefined,
+  };
+}
 
 export function handleFrom(input: ToolInputType<typeof boardInsightsToolSchema>): AggregateFromTableInput {
   return {
@@ -27,12 +61,15 @@ export function handleFilters(input: ToolInputType<typeof boardInsightsToolSchem
   }
   const filters: ItemsQuery = {};
   if (input.filters) {
-    filters.rules = input.filters.map((rule) => ({
-      column_id: rule.columnId,
-      compare_value: rule.compareValue,
-      operator: rule.operator,
-      compare_attribute: rule.compareAttribute,
-    }));
+    filters.rules = input.filters.map((rule) => {
+      const normalized = normalizeBetweenRule(rule);
+      return {
+        column_id: normalized.columnId,
+        compare_value: normalized.compareValue,
+        operator: normalized.operator,
+        compare_attribute: normalized.compareAttribute,
+      };
+    });
     filters.operator = input.filtersOperator;
   }
   if (input.orderBy) {


### PR DESCRIPTION
## Summary

`board_insights` shares `filterRulesSchema` with `get_board_items_page`, which legitimately uses `compareAttribute` for cross-column comparisons. The aggregate resolver behind `board_insights` doesn't support it — for `between` it needs the range as a two-element `compareValue` array.

LLMs seeing the shared schema cargo-cult `compareAttribute` as the range end and produce:

```json
{ "operator": "between", "compareValue": "<from>", "compareAttribute": "<to>" }
```

The resolver then rejects with:

```
{"operator":"BETWEEN__<to>","reason":"no_operator_config"}   (HTTP 400)
```

Observed in production for `board_insights` calls from scheduled agents, e.g. request_ids `d331c33a-5cfd-4976-9b83-af63f3fe3ee0` and `7da6d747-6c03-4087-adfc-0cfe5aee5009`.

## Change

`handleFilters` in `board-insights-utils.ts` now detects the split shape and merges it back into `compareValue: [from, to]` before dispatch. Scope is deliberately narrow:

- Only `board_insights` (leaves `get_board_items_page` behavior untouched — `compareAttribute` remains valid there).
- Only fires when `operator === 'between'`, `compareValue` is a scalar, AND `compareAttribute` is a scalar.
- Already-array `compareValue` is untouched.
- Non-`between` rules that carry `compareAttribute` are untouched.

Bumps `@mondaydotcomorg/agent-toolkit` to `5.61.7` and adds a CHANGELOG entry.

## Alternative considered

Prompt-only fix (add a `between`-specific rule to the shared filter schema description). Rejected because the shared schema is used by tools where `compareAttribute` IS valid, so the "not supported" caveat would be misleading in half the callers. Deterministic coercion at the tool boundary is safer.

## Test plan

- [x] `npx jest board-insights-tool.test.ts` — 41 tests pass (3 new: split-shape coercion, already-array untouched, non-`between` untouched).
- [ ] Manual: run an agent that sends a `between` date range on `board_insights` and confirm the resolver accepts it.