### PR TITLE
monday-crm v0.5.0: add activity-insights skill

### DIFF
--- a/plugins/monday-crm/.claude-plugin/plugin.json
+++ b/plugins/monday-crm/.claude-plugin/plugin.json
@@ -2,8 +2,8 @@
   "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "monday-crm",
   "displayName": "monday CRM",
-  "description": "Run your sales pipeline in monday CRM from plain language. Start the day with a ranked deal briefing, build a forecast, turn meeting notes into deal updates, set up a CRM workspace from scratch, keep your data clean, manage sequences end-to-end, log calls and meetings to timelines, and set up automations — every result written straight back into monday. Built on the official monday MCP connector.",
-  "version": "0.4.0",
+  "description": "Run your sales pipeline in monday CRM from plain language. Start the day with a ranked deal briefing, build a forecast, turn meeting notes into deal updates, set up a CRM workspace from scratch, keep your data clean, manage sequences end-to-end, log calls and meetings to timelines, analyze team activity and rep performance, and set up automations — every result written straight back into monday. Built on the official monday MCP connector.",
+  "version": "0.5.0",
   "defaultEnabled": false,
   "author": {
     "name": "monday.com",
@@ -27,6 +27,7 @@
     "sequence",
     "automation",
     "activity",
-    "timeline"
+    "timeline",
+    "activity-insights"
   ]
 }

--- a/plugins/monday-crm/CHANGELOG.md
+++ b/plugins/monday-crm/CHANGELOG.md
@@ -3,6 +3,16 @@
 All notable changes to the `monday-crm` Claude plugin are documented here.
 Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.5.0] — 2026-08-05
+
+### Added
+- **`activity-insights`** — analyze CRM activity data across the team: rep performance, call/email/meeting volume, per-type breakdowns, and rep comparisons. Uses `get-activity-insights` (now available on the external connector after `DaPulse/crm-mcp` PR #287) to return aggregated counts server-side. Synthesizes results as natural language; redirects item-level content questions to `get-timeline-items`.
+
+### Changed
+- `log-activity`: removed "Sidekick-only" guard on `get-activity-insights`; the tool is now available on the public connector. Step 4 (Read) now routes aggregate/team queries to the `activity-insights` skill. Added `activity-insights` to cross-skill handoffs.
+
+---
+
 ## [0.4.0] — 2026-07-12
 
 ### Added

--- a/plugins/monday-crm/skills/activity-insights/SKILL.md
+++ b/plugins/monday-crm/skills/activity-insights/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: activity-insights
+description: >
+  Analyze CRM activity data — rep performance, call and email volume, team activity breakdowns, and engagement stats. Use when someone says "how many calls did the team make", "show me rep activity", "who's the most active rep", "activity breakdown this week", "how is the team performing", "what's our outreach volume", "compare rep activity", "call stats", "email volume by rep", "activity report", or "team engagement stats".
+argument-hint: "[team / rep name / date range — 'rep activity this week', 'call breakdown for John', 'team performance last month']"
+user-invocable: true
+allowed-tools: [Read, mcp__monday__get_user_context, mcp__monday__search, mcp__monday__get_board_info, mcp__monday__get_board_items_page, mcp__monday__get-activity-insights, mcp__monday__get-timeline-items, mcp__monday__list_users_and_teams]
+---
+
+# Activity Insights
+
+Flow: **Trigger → Connector check → Resolve board → Build query → Fetch insights → Synthesize**.
+
+## Input
+- Optional: argument describing the analysis (e.g., "rep activity this week", "call breakdown for the team").
+- Optional: rep name, date range, or grouping preference.
+
+## Output
+A synthesized summary with specific numbers and rep-level breakdowns. Never raw JSON.
+
+## Knowledge
+
+- `get-activity-insights` returns **aggregated counts** — not individual activity records. For activity history with content, use `get-timeline-items`.
+- **Default time range is 7 days** — no need to pass a date if the user asks about "recent" or "this week".
+- **groupBy accepts 1–2 fields:** `["type"]` for activity breakdown; `["userId", "type"]` for per-rep breakdown; `["userId"]` for rep totals only.
+- `board_id` is required — always resolve it before calling the tool.
+- Present results as natural language insights — never dump the raw results array.
+
+## Tools (MCP)
+
+- `get-activity-insights` — aggregated activity stats (counts, duration) grouped by rep, type, or item.
+- `get_user_context` — user identity and account info.
+- `search` / `get_board_info` / `get_board_items_page` — resolve boards and items.
+- `list_users_and_teams` — resolve rep names to user IDs for filtering.
+- `get-timeline-items` — fallback for item-level activity detail (content, not aggregates).
+
+## When to use each groupBy
+
+| User says | groupBy | Notes |
+|---|---|---|
+| "How many calls did each rep make?" | `["userId", "type"]` | Per-rep breakdown |
+| "What's the activity breakdown this week?" | `["type"]` | Team totals by type |
+| "Who's the most active rep?" | `["userId"]` | Rep totals only |
+| "How many emails did John send?" | `["type"]` | + `userIds` filter |
+| "Activity on the Acme deal?" | `["type"]` | + `itemIds` filter — or use `get-timeline-items` for content |
+| "Compare rep performance last month" | `["userId", "type"]` | Set `fromDate`/`toDate` |
+
+---
+
+## Step 0: Connector check
+
+1. Call `mcp__monday__get_user_context`. On error → print connector install prompt, stop.
+
+---
+
+## Step 1: Resolve board
+
+`get-activity-insights` requires a `board_id`.
+
+1. If a board name is clear from the argument → `mcp__monday__search` or `mcp__monday__get_board_info` to resolve the ID.
+2. If multiple CRM boards exist → ask: *"Which board should I analyze — Deals, Contacts, or Leads?"*
+3. No board context → `mcp__monday__search({ query: "deals" })` to find the most likely CRM board. Still ambiguous → ask.
+
+---
+
+## Step 2: Build query parameters
+
+Parse the argument:
+
+**groupBy:**
+- Reps, "who", "by rep", "each rep" → `["userId", "type"]`
+- "breakdown", "by type", "what kind" → `["type"]`
+- Default → `["userId", "type"]`
+
+**Date range:**
+- "this week" → 7-day default (no params needed)
+- "last month" → `fromDate`: 30 days ago
+- "today" → `fromDate`: start of today
+- Explicit dates → parse and pass `fromDate` / `toDate`
+
+**Filters:**
+- Rep name mentioned → resolve via `mcp__monday__list_users_and_teams`, pass `userIds`
+- Item/deal name mentioned → resolve item ID, pass `itemIds` (or redirect to `get-timeline-items` for content)
+
+**aggregationType:** default `count`. Use `sum` / `avg` for duration questions ("how long were the calls").
+
+---
+
+## Step 3: Fetch and synthesize
+
+1. Call `mcp__monday__get-activity-insights` with resolved parameters.
+2. If `total_results === 0`:
+   *"No activities found on \<board\> in the last \<window\>. The team may not have logged activities yet, or try a wider date range."*
+3. Synthesize results:
+   - Lead with the headline: *"Your team logged 92 activities this week."*
+   - Break down by type: *"42 emails, 28 calls, 15 meetings, and 7 notes."*
+   - Call out top performers if grouped by rep: *"Alex led with 34 activities, followed by Sam (28) and Jordan (19)."*
+   - Flag low activity if relevant: *"4 reps logged fewer than 5 activities this week."*
+
+---
+
+## Cross-skill handoffs
+
+- **To log-activity:** insights show a rep with zero activity → *"Want to log a recent call or meeting for them?"*
+- **To run-sequence:** low outreach volume → suggest enrolling contacts in a sequence.
+- **From daily-briefing:** briefing surfaces activity gaps → this skill provides the full breakdown.
+- **To get-timeline-items:** user asks for actual content (what was said, meeting notes) rather than counts.
+
+---
+
+## Error handling reference
+
+| Failure | Behavior |
+|---|---|
+| Connector missing | Stop; print install prompt. |
+| Board not resolved | Ask user to specify the board. |
+| Tool unavailable | *"Activity insights aren't available on the connector for your account yet."* |
+| No results | Confirm date range; suggest widening. |
+| Rep name not found | Ask for clarification or list available reps via `list_users_and_teams`. |
+| Item-level content request | Redirect to `get-timeline-items`; `get-activity-insights` operates at board level. |
+
+---
+
+## Completion criteria
+
+- [ ] Connector check passed.
+- [ ] `board_id` resolved before calling the tool.
+- [ ] Query parameters derived from context — not hardcoded defaults.
+- [ ] Results synthesized into natural language — no raw JSON.
+- [ ] Zero-result case handled gracefully.
+- [ ] Item-level content requests redirected to `get-timeline-items`.

--- a/plugins/monday-crm/skills/log-activity/SKILL.md
+++ b/plugins/monday-crm/skills/log-activity/SKILL.md
@@ -22,7 +22,7 @@ Flow: **Trigger → Detect intent (log / read / update) → Resolve CRM item →
 ## Knowledge
 - Timeline = the activity feed on any CRM item (deal, contact, lead, account).
 - Activity types: calls, meetings, notes, emails (read-only from timeline), custom types per account.
-- `get-activity-insights` is Sidekick-only — not available on the public connector. Skip it; surface raw timeline data instead.
+- For aggregated stats (team totals, rep comparisons), use the **activity-insights** skill — `get-activity-insights` is more efficient than counting raw timeline items.
 - Timeline items are append-only in the UI; the API allows updates to existing entries.
 - `update-timeline-item` visibility on external connector is unconfirmed — degrade gracefully if it fails.
 
@@ -40,6 +40,7 @@ Flow: **Trigger → Detect intent (log / read / update) → Resolve CRM item →
 - **From run-sequence:** when a sequence triggers a manual call step, suggest logging the call outcome.
 - **To morning-briefing:** logged activities feed the daily brief's "recent activity" section.
 - **From daily-briefing:** brief surfaces items with no activity in N days → suggest logging.
+- **To activity-insights:** when the user asks about team totals or rep comparisons rather than a specific item's history.
 
 ---
 
@@ -156,7 +157,7 @@ If the tool call fails, fall back to `create_timeline_note` with the same conten
 2. Parse time filter from argument (this week / last 7 days / today / default last 10).
 3. Format output as a table with Date, Type, Summary columns.
 4. If zero activities: *"No activities on <item name> in <window>. Want to log one now?"*
-5. Do NOT call `get-activity-insights` — it's Sidekick-only.
+5. For team-wide aggregated stats (totals by rep or type), use the **activity-insights** skill instead.
 
 ---
 
@@ -199,7 +200,6 @@ If the tool call fails, fall back to `create_timeline_note` with the same conten
 | Update fails | Surface error; suggest editing in monday CRM UI. |
 | Timeline empty on read | Offer to log a new activity. |
 | Tool unavailable (Gateway) | *"Activity logging tools aren't available on the connector yet — use the monday CRM UI for now."* |
-| `get-activity-insights` called | Never call it — Sidekick-only boundary. |
 
 ---
 
@@ -212,4 +212,3 @@ If the tool call fails, fall back to `create_timeline_note` with the same conten
 - [ ] Structured activities used when available; notes as fallback.
 - [ ] No timeline entries deleted (hard rail).
 - [ ] Errors surfaced with actionable guidance.
-- [ ] `get-activity-insights` never called.


### PR DESCRIPTION
## Summary

- **New skill `activity-insights`**: analyze CRM activity data — rep performance, call/email/meeting volume, per-type breakdowns, and rep comparisons. Uses `get-activity-insights` (exposed on external connector in `DaPulse/crm-mcp` PR #287) to return aggregated counts server-side. Synthesizes results as natural language; redirects item-level content questions to `get-timeline-items`.
- **`log-activity` updated**: removed the "Sidekick-only" guard on `get-activity-insights`. The tool is now available on the public connector. Aggregate/team queries routed to the new skill via cross-skill handoffs.
- Plugin version bumped to 0.5.0; description updated to mention activity insights.

## Dependency

This skill requires `DaPulse/crm-mcp` PR #287 (`feature/expose-get-activity-insights`) to be merged first — that PR changes `visibility: 'internal'` → `'public'` on the tool. The skill will gracefully surface an "unavailable" error until then.

## Test plan

- [ ] Trigger with "how many calls did the team make this week" — should resolve Deals board, call `get-activity-insights` with `groupBy: ["userId","type"]`, return synthesized natural language.
- [ ] Trigger with "who's the most active rep" — should use `groupBy: ["userId"]`.
- [ ] Trigger with "activity on the Acme deal?" — should redirect to `get-timeline-items`.
- [ ] Trigger `log-activity` for reading a timeline — should no longer contain the "Sidekick-only" guard in Step 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)