### PR TITLE
feat(agent-toolkit): require capability check before get_asset_upload_url

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 5.62.1
+
+### get_asset_upload_url — require capability check before calling
+
+- Prepended a precondition to the tool description: only call `get_asset_upload_url` if the caller can execute a direct HTTP PUT with binary data and read response headers; otherwise it should tell the user direct file upload isn't supported instead of calling the tool
+- Addresses a metrics gap where `get_asset_upload_url` was called far more often than `finalize_asset_upload` completed, consistent with callers (e.g. plain conversational chat agents without shell/HTTP execution) generating presigned URLs they have no way to actually use
+
 ## 5.62.0
 
 ### search — filter ITEMS search by creatorIds

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.62.0",
+  "version": "5.62.1",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.test.ts
@@ -79,5 +79,6 @@ describe('GetAssetUploadUrlTool', () => {
     expect(tool.getDescription()).toContain('curl');
     expect(tool.getDescription()).toContain('ETag');
     expect(tool.getDescription()).toContain('finalize_asset_upload');
+    expect(tool.getDescription()).toContain('Only call this tool if you can execute a direct HTTP PUT');
   });
 });

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.ts
@@ -6,7 +6,12 @@ import { createUploadMutationDev } from './get-asset-upload-url.graphql.dev';
 export const getAssetUploadUrlSchema = {
   fileName: z.string().describe('The name of the file to upload, including extension (e.g. "report.pdf")'),
   contentType: z.string().describe('The MIME type of the file (e.g. "application/pdf", "image/png", "text/plain")'),
-  fileSize: z.number().int().positive().max(524288000).describe('The file size in bytes. Maximum 500MB (524288000 bytes)'),
+  fileSize: z
+    .number()
+    .int()
+    .positive()
+    .max(524288000)
+    .describe('The file size in bytes. Maximum 500MB (524288000 bytes)'),
 };
 
 interface CreateUploadMutation {
@@ -30,6 +35,11 @@ export class GetAssetUploadUrlTool extends BaseMondayApiTool<typeof getAssetUplo
 
   getDescription(): string {
     return (
+      'Only call this tool if you can execute a direct HTTP PUT request with binary file data and read the ' +
+      'response headers (e.g. via a shell/curl or an HTTP client tool available to you). This tool only returns ' +
+      'a presigned upload URL — it does not perform the upload itself. If you do not have that capability in the ' +
+      'current context (e.g. a plain conversational chat with no shell/code execution), do not call this tool — ' +
+      'tell the user that direct file upload is not supported here instead.\n\n' +
       'Get a presigned URL to upload a file to monday.com. Returns an upload_id and upload_url.\n\n' +
       'After calling this tool, upload the file to the returned URL using an HTTP PUT request ' +
       'and capture the ETag header from the response:\n\n' +
@@ -47,7 +57,9 @@ export class GetAssetUploadUrlTool extends BaseMondayApiTool<typeof getAssetUplo
     return getAssetUploadUrlSchema;
   }
 
-  protected async executeInternal(input: ToolInputType<typeof getAssetUploadUrlSchema>): Promise<ToolOutputType<never>> {
+  protected async executeInternal(
+    input: ToolInputType<typeof getAssetUploadUrlSchema>,
+  ): Promise<ToolOutputType<never>> {
     const res = await this.mondayApi.request<CreateUploadMutation>(
       createUploadMutationDev,
       {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.ts
@@ -35,11 +35,9 @@ export class GetAssetUploadUrlTool extends BaseMondayApiTool<typeof getAssetUplo
 
   getDescription(): string {
     return (
-      'Only call this tool if you can execute a direct HTTP PUT request with binary file data and read the ' +
-      'response headers (e.g. via a shell/curl or an HTTP client tool available to you). This tool only returns ' +
-      'a presigned upload URL — it does not perform the upload itself. If you do not have that capability in the ' +
-      'current context (e.g. a plain conversational chat with no shell/code execution), do not call this tool — ' +
-      'tell the user that direct file upload is not supported here instead.\n\n' +
+      'Only call this tool if you can execute a direct HTTP PUT with binary file data and read response headers ' +
+      "(e.g. via shell/curl). If you can't, tell the user direct file upload isn't supported here — " +
+      "don't call this tool.\n\n" +
       'Get a presigned URL to upload a file to monday.com. Returns an upload_id and upload_url.\n\n' +
       'After calling this tool, upload the file to the returned URL using an HTTP PUT request ' +
       'and capture the ETag header from the response:\n\n' +


### PR DESCRIPTION
## Summary
- Presigned-URL generation for `get_asset_upload_url` was outpacing completed uploads (i.e. `finalize_asset_upload` calls), consistent with some callers being unable to perform the intermediate step — a direct HTTP PUT of binary file data — e.g. plain conversational chat agents without shell/HTTP execution capability.
- `get_asset_upload_url`'s description now opens with an explicit precondition instructing the calling agent to only invoke the tool if it can perform a direct HTTP PUT and read response headers, and to tell the user upload isn't supported otherwise, instead of generating an `upload_id` that's never finalized.
- Bumped `@mondaydotcomorg/agent-toolkit` to `5.62.1` with a changelog entry.

## Test plan
- [x] `npx jest get-asset-upload-url-tool finalize-asset-upload-tool` — all 8 tests pass, including a new assertion on the precondition text
- [x] `npx eslint` / `npx prettier` on the changed tool directory — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)