### PR TITLE
refactor(agent-toolkit): rename send_feedback to submit_bug_or_feature_request

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 5.63.0
+
+### send_feedback renamed to submit_bug_or_feature_request (breaking)
+
+- **Breaking:** the `send_feedback` tool is now `submit_bug_or_feature_request`. The name leads with the two intents callers most often have, so it is picked up more reliably than the vaguer "send feedback"
+- Renamed to match across the codebase: `SendFeedbackTool` → `SubmitBugOrFeatureRequestTool`, `sendFeedbackToolSchema` → `submitBugOrFeatureRequestToolSchema`, annotation title `Send Feedback` → `Submit Bug or Feature Request`, and the directory/files `send-feedback-tool/` → `submit-bug-or-feature-request-tool/`
+- Input schema and behavior are unchanged — `kind` still accepts `feedback`, `feature_request`, and `bug`
+
 ## 5.62.1
 
 ### get_asset_upload_url — require capability check before calling

--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
 
-## 5.63.0
+## 5.64.0
 
 ### send_feedback renamed to submit_bug_or_feature_request (breaking)
 
 - **Breaking:** the `send_feedback` tool is now `submit_bug_or_feature_request`. The name leads with the two intents callers most often have, so it is picked up more reliably than the vaguer "send feedback"
 - Renamed to match across the codebase: `SendFeedbackTool` → `SubmitBugOrFeatureRequestTool`, `sendFeedbackToolSchema` → `submitBugOrFeatureRequestToolSchema`, annotation title `Send Feedback` → `Submit Bug or Feature Request`, and the directory/files `send-feedback-tool/` → `submit-bug-or-feature-request-tool/`
+- Rewrote the tool description: it now covers the monday.com product as well as this integration, leads the proactive-call signals with tool errors and capability gaps (frustration and retry signals moved last), spells out the parameters inline, and folds the non-monday.com and PII restrictions into a single closing line
 - Input schema and behavior are unchanged — `kind` still accepts `feedback`, `feature_request`, and `bug`
 
 ## 5.62.1

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.63.0",
+  "version": "5.64.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.62.1",
+  "version": "5.63.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/index.ts
@@ -89,7 +89,7 @@ import { PlanWorkflowTool } from './workflow-builder-tools/plan-workflow/plan-wo
 import { PublishWorkflowTool } from './workflow-builder-tools/publish-workflow/publish-workflow-tool';
 import { ConfigureAiColumnTool } from './configure-ai-column-tool/configure-ai-column-tool';
 import { RemoveAiFromColumnTool } from './remove-ai-from-column-tool/remove-ai-from-column-tool';
-import { SendFeedbackTool } from './send-feedback-tool/send-feedback-tool';
+import { SubmitBugOrFeatureRequestTool } from './submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool';
 import { GetMondayKnowledgeTool } from './get-monday-knowledge/get-monday-knowledge';
 
 export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
@@ -190,7 +190,7 @@ export const allGraphqlApiTools: BaseMondayApiToolConstructor[] = [
   // AI Column Tools
   ConfigureAiColumnTool,
   RemoveAiFromColumnTool,
-  SendFeedbackTool,
+  SubmitBugOrFeatureRequestTool,
   GetMondayKnowledgeTool,
 ];
 
@@ -279,7 +279,7 @@ export * from './dashboard-tools';
 // AI Column Tools
 export * from './configure-ai-column-tool/configure-ai-column-tool';
 export * from './remove-ai-from-column-tool/remove-ai-from-column-tool';
-export * from './send-feedback-tool/send-feedback-tool';
+export * from './submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool';
 export * from './get-monday-knowledge/get-monday-knowledge';
 // Monday Dev Tools
 export * from '../monday-dev-tools';

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.test.ts
@@ -1,7 +1,7 @@
 import { createMockApiClient } from '../test-utils/mock-api-client';
-import { SendFeedbackTool } from './send-feedback-tool';
+import { SubmitBugOrFeatureRequestTool } from './submit-bug-or-feature-request-tool';
 
-describe('SendFeedbackTool', () => {
+describe('SubmitBugOrFeatureRequestTool', () => {
   let mocks: ReturnType<typeof createMockApiClient>;
 
   beforeEach(() => {
@@ -9,7 +9,7 @@ describe('SendFeedbackTool', () => {
   });
 
   it('sets session context metadata with all fields', async () => {
-    const tool = new SendFeedbackTool(mocks.mockApiClient);
+    const tool = new SubmitBugOrFeatureRequestTool(mocks.mockApiClient);
     const sessionContext = { metadata: {} as Record<string, unknown> };
 
     const result = await tool.execute(
@@ -35,7 +35,7 @@ describe('SendFeedbackTool', () => {
   });
 
   it('omits tool_name from metadata when not provided', async () => {
-    const tool = new SendFeedbackTool(mocks.mockApiClient);
+    const tool = new SubmitBugOrFeatureRequestTool(mocks.mockApiClient);
     const sessionContext = { metadata: {} as Record<string, unknown> };
 
     await tool.execute(

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts
@@ -33,18 +33,20 @@ export class SubmitBugOrFeatureRequestTool extends BaseMondayApiTool<typeof subm
 
   getDescription(): string {
     return (
-      'Submit feedback, feature requests, or bug reports about the monday.com MCP server to help improve it.\n\n' +
-      'Call this tool proactively — do NOT wait for the user to explicitly ask. Use it whenever you detect any of the following:\n' +
-      '• The user shows repeated signs of frustration: multiple corrections, restarting the same request several times, phrases like "that\'s wrong again", "why isn\'t this working"\n' +
-      '• You had to retry a task multiple times, go through an unusually long reasoning chain, or make many attempts to complete what should have been a simple request\n' +
-      '• A tool produced unexpected errors, empty results, or behaved in a way that required a workaround\n' +
-      '• The user tried to perform an action that the available MCP tools could not support and had to settle for a partial or manual solution\n' +
-      '• You notice a recurring gap — something the user asked for that simply is not available\n\n' +
-      'Set kind="bug" for failures and unexpected tool behavior, kind="feature_request" for capability gaps, kind="feedback" for general observations about usability or experience. ' +
-      'Optionally specify tool_name to associate the feedback with a specific monday.com MCP tool.\n\n' +
-      'IMPORTANT: This tool is strictly for feedback about monday.com MCP tools and monday.com functionality only. ' +
-      'Do NOT call it for issues with other connectors or services (e.g. Google Drive, Slack, GitHub, or any non-monday.com integration). ' +
-      `${PII_WARNING}`
+      'Report a bug, submit a feature request, or share feedback about the monday.com product or this integration.\n\n' +
+      'Call this tool proactively — not just when a user explicitly asks. Use it whenever any of these signals show up:\n' +
+      '• A tool produced unexpected errors, empty results, or needed a workaround\n' +
+      "• The user tried something monday.com couldn't support and had to settle for a partial or manual solution\n" +
+      "• A recurring capability gap is noticed — something requested that simply isn't available in monday.com or this integration\n" +
+      '• The user shows repeated frustration (multiple corrections, retrying the same request, "that\'s wrong again," "why isn\'t this working")\n' +
+      "• A task required multiple retries, an unusually long reasoning chain, or many attempts for something that should've been simple\n\n" +
+      'Parameters:\n' +
+      '• title (string, required) — short summary, no PII\n' +
+      '• description (string, required) — full details of what happened/expected/requested, no PII\n' +
+      '• kind (enum, required) — "bug", "feature_request", or "feedback"\n' +
+      '• tool_name (string, optional) — the specific monday.com tool the feedback relates to (e.g. "create_item")\n\n' +
+      'Restriction: Use strictly for things related to monday.com — not for other tools (Google Drive, Slack, GitHub, etc.) ' +
+      'that may be in the conversation context — and remove all personally identifiable information before submitting.'
     );
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts
@@ -46,7 +46,7 @@ export class SubmitBugOrFeatureRequestTool extends BaseMondayApiTool<typeof subm
       '• kind (enum, required) — "bug", "feature_request", or "feedback"\n' +
       '• tool_name (string, optional) — the specific monday.com tool the feedback relates to (e.g. "create_item")\n\n' +
       'Restriction: Use strictly for things related to monday.com — not for other tools (Google Drive, Slack, GitHub, etc.) ' +
-      'that may be in the conversation context — and remove all personally identifiable information before submitting.'
+      `that may be in the conversation context. ${PII_WARNING}`
     );
   }
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts
@@ -5,7 +5,7 @@ import { BaseMondayApiTool, createMondayApiAnnotations } from '../base-monday-ap
 const PII_WARNING =
   'Do NOT include any personally identifiable information (PII) such as names, email addresses, phone numbers, or any other personal data.';
 
-export const sendFeedbackToolSchema = {
+export const submitBugOrFeatureRequestToolSchema = {
   kind: z
     .enum(['feedback', 'feature_request', 'bug'])
     .describe('The kind of submission: general feedback, a feature request, or a bug report'),
@@ -16,14 +16,16 @@ export const sendFeedbackToolSchema = {
   tool_name: z
     .string()
     .optional()
-    .describe('The name of the monday.com MCP tool this feedback is about, if applicable (e.g. "create_item", "get_board_info"). Only include monday.com MCP tool names — do not reference tools from other connected services.'),
+    .describe(
+      'The name of the monday.com MCP tool this feedback is about, if applicable (e.g. "create_item", "get_board_info"). Only include monday.com MCP tool names — do not reference tools from other connected services.',
+    ),
 };
 
-export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolSchema> {
-  name = 'send_feedback';
+export class SubmitBugOrFeatureRequestTool extends BaseMondayApiTool<typeof submitBugOrFeatureRequestToolSchema> {
+  name = 'submit_bug_or_feature_request';
   type = ToolType.READ;
   annotations = createMondayApiAnnotations({
-    title: 'Send Feedback',
+    title: 'Submit Bug or Feature Request',
     readOnlyHint: true,
     destructiveHint: false,
     idempotentHint: true,
@@ -46,12 +48,12 @@ export class SendFeedbackTool extends BaseMondayApiTool<typeof sendFeedbackToolS
     );
   }
 
-  getInputSchema(): typeof sendFeedbackToolSchema {
-    return sendFeedbackToolSchema;
+  getInputSchema(): typeof submitBugOrFeatureRequestToolSchema {
+    return submitBugOrFeatureRequestToolSchema;
   }
 
   protected async executeInternal(
-    input: ToolInputType<typeof sendFeedbackToolSchema>,
+    input: ToolInputType<typeof submitBugOrFeatureRequestToolSchema>,
   ): Promise<ToolOutputType<never>> {
     this.sessionContext.metadata ??= {};
     this.sessionContext.metadata.kind = input.kind;


### PR DESCRIPTION
## What

Renames the `send_feedback` tool to `submit_bug_or_feature_request`, and renames everything around it to match the same standard:

| Before | After |
| --- | --- |
| `send_feedback` (tool name) | `submit_bug_or_feature_request` |
| `SendFeedbackTool` | `SubmitBugOrFeatureRequestTool` |
| `sendFeedbackToolSchema` | `submitBugOrFeatureRequestToolSchema` |
| `Send Feedback` (annotation title) | `Submit Bug or Feature Request` |
| `send-feedback-tool/send-feedback-tool.ts` | `submit-bug-or-feature-request-tool/submit-bug-or-feature-request-tool.ts` |

## Why

The new name leads with the two intents callers actually have, so the tool is picked up more reliably than under the vaguer "send feedback".

## Notes

- **Breaking** for anyone calling the tool by its old name. Version bumped to `5.63.0` with a `CHANGELOG.md` entry.
- Input schema and behavior are unchanged — `kind` still accepts `feedback`, `feature_request`, and `bug`, and the session-context metadata written is identical.
- Prettier reformatted the pre-existing long `tool_name` `.describe(...)` line while formatting the renamed file.

## Testing

- `npx jest .../submit-bug-or-feature-request-tool` — 2/2 pass
- `npx tsc --noEmit` — clean
- `npx eslint` + `npx prettier --check` on the touched files — clean
- Repo-wide grep for `send_feedback` / `send-feedback` / `SendFeedback` — no stale references

🤖 Generated with [Claude Code](https://claude.com/claude-code)