### PR TITLE
feat(agent-toolkit): add MLS hierarchy support to board tools

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info-tool.ts
@@ -27,7 +27,8 @@ export class GetBoardInfoTool extends BaseMondayApiTool<typeof getBoardInfoToolS
   getDescription(): string {
     return (
       'Get comprehensive board information including metadata, structure, owners, and configuration. ' +
-      'Also returns the board\'s views (e.g. table views, filter views) — each view includes its id, name, type, and a structured filter object. '
+      'Also returns the board\'s views (e.g. table views, filter views) — each view includes its id, name, type, and a structured filter object. ' +
+      'The response includes hierarchy_type which indicates if the board is a multi-level board ("multi_level") where items can have nested subitems up to 5 levels deep on the same board. On multi-level boards, subitems share the same columns as parent items and subItemColumns will be null.'
     );
   }
 
@@ -64,6 +65,12 @@ export class GetBoardInfoTool extends BaseMondayApiTool<typeof getBoardInfoToolS
     }
 
     const subItemsBoardId = subTasksColumn.settings.boardIds[0];
+
+    // On MLS boards, boardIds[0] is the board's own ID (self-reference) —
+    // subitems live on the same board, so no separate query is needed.
+    if (subItemsBoardId === board.id) {
+      return null;
+    }
 
     const response = await this.mondayApi.request<GetBoardInfoJustColumnsQuery>(getBoardInfoJustColumns, {
       boardId: subItemsBoardId,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.graphql.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-info/get-board-info.graphql.ts
@@ -16,6 +16,7 @@ export const getBoardInfo = gql`
       updated_at
 
       # Board Configuration
+      hierarchy_type
       item_terminology
       items_count
       items_limit

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-items-page-tool/get-board-items-page-tool.graphql.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-items-page-tool/get-board-items-page-tool.graphql.ts
@@ -7,6 +7,9 @@ export const getBoardItemsPage = gql`
     url
     created_at
     updated_at
+    parent_item {
+      id
+    }
     group @include(if: $includeGroup) {
       id
       title
@@ -56,6 +59,7 @@ export const getBoardItemsPage = gql`
     boards(ids: [$boardId]) {
       id
       name
+      hierarchy_type
       items_page(limit: $limit, cursor: $cursor, query_params: $queryParams) {
         items {
           ...ItemDataFragment

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-items-page-tool/get-board-items-page-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-board-items-page-tool/get-board-items-page-tool.ts
@@ -39,6 +39,7 @@ type GetBoardItemsPageResult = {
   board: {
     id?: string;
     name?: string;
+    hierarchy_type?: string | null;
   };
   items: GetBoardItemsPageResultItem[];
   pagination: {
@@ -54,6 +55,7 @@ type GetBoardItemsPageResultItem = {
   url?: string;
   created_at: any;
   updated_at: any;
+  parent_item_id?: string | null;
   column_values?: Record<string, any>;
   group?: { id: string; title: string };
   item_description?: { id?: string | null; blocks: Array<{ id: string; type?: string | null; content?: any }> };
@@ -156,6 +158,7 @@ export class GetBoardItemsPageTool extends BaseMondayApiTool<GetBoardItemsPageTo
       'Returns structured JSON with item details, creation/update timestamps, and pagination info. ' +
       'Use the nextCursor parameter from the response to get the next page of results when has_more is true. ' +
       'To retrieve an item description (the rich-text body/details of a monday.com item), set includeItemDescription to true — the response will include the item description document blocks with their content, type, and id. Use this whenever the user asks about an item description, body, details, or notes. ' +
+      '[MULTI-LEVEL BOARDS]: The response includes hierarchy_type on the board ("multi_level" for MLS boards) and parent_item_id on each item. On multi-level boards, items form a tree (up to 5 levels). Use includeSubItems to get all descendants (returned flat with parent_item_id to reconstruct the tree). Top-level items have no parent_item_id; subitems reference their parent. ' +
       '[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board structure (column IDs, column types, status labels, etc.), first use get_board_info to understand the board metadata. This is essential for constructing proper filters and knowing which columns are available. ' +
       '[REQUIRED PRECONDITION]: For board-relation / cross-board linking tasks, call link_board_items_workflow before using this tool. ' +
       'VIEW-BASED FILTERING: If the user refers to a board view by name (e.g. "show me items in the Overdue view"), first call get_board_info to get the board views, find the matching view by name, then extract its filter field and pass it as the filters argument here.'
@@ -243,6 +246,7 @@ export class GetBoardItemsPageTool extends BaseMondayApiTool<GetBoardItemsPageTo
       board: {
         id: board?.id,
         name: board?.name,
+        hierarchy_type: (board as any)?.hierarchy_type || null,
       },
       items: items.map((item) => this.mapItem(item, input)),
       pagination: {
@@ -256,12 +260,14 @@ export class GetBoardItemsPageTool extends BaseMondayApiTool<GetBoardItemsPageTo
   }
 
   private mapItem(item: Item | SubItem, input: ToolInputType<GetBoardItemsPageToolInput>): GetBoardItemsPageResultItem {
+    const parentItemId = (item as any).parent_item?.id || null;
     const itemResult: GetBoardItemsPageResultItem = {
       id: item.id,
       name: item.name,
       url: item.url,
       created_at: item.created_at,
       updated_at: item.updated_at,
+      ...(parentItemId && { parent_item_id: parentItemId }),
     };
 
     if (input.includeColumns && item.column_values) {


### PR DESCRIPTION
## Summary
- **get_board_items_page**: Add `parent_item { id }` to the item fragment and `hierarchy_type` to the board query. Agents can now detect MLS boards and reconstruct the item tree from `parent_item_id` pointers.
- **get_board_info**: Add `hierarchy_type` to output. Guard `getSubItemsBoardAsync` against MLS self-reference (`boardIds[0] === board.id`) — prevents a redundant round-trip that misreports board structure on multi-level boards.
- **Tool descriptions**: Updated both tools with MLS guidance so agents understand multi-level board behavior.

Addresses gaps G2, G3, and G4 from the MLS gap analysis.

## Test plan
- [ ] Query an MLS board via `get_board_items_page` — verify `hierarchy_type: "multi_level"` appears in board response
- [ ] Query an MLS board with `includeSubItems: true` — verify subitems include `parent_item_id`
- [ ] Query a classic board — verify `hierarchy_type` is `null` and top-level items have no `parent_item_id`
- [ ] Call `get_board_info` on an MLS board — verify `subItemColumns` is null (no self-referencing query) and `hierarchy_type` is present
- [ ] Call `get_board_info` on a classic board with subitems — verify `subItemColumns` still works as before
- [ ] Run codegen to regenerate types (`npm run codegen`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)