### PR TITLE
feat(agent-toolkit): support create_board template flags

### DIFF
--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.test.ts
@@ -37,7 +37,45 @@ describe('CreateBoardTool', () => {
     });
   });
 
+  it('includes template flags in variables when provided', async () => {
+    mocks.setResponse(successfulResponse);
+    const tool = new CreateBoardTool(mocks.mockApiClient);
+
+    await tool.execute({
+      boardName: 'Test Board',
+      boardKind: BoardKind.Public,
+      useMlsTemplate: true,
+      useDatasetTemplate: false,
+    });
+
+    expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createBoard'), {
+      boardName: 'Test Board',
+      boardKind: BoardKind.Public,
+      boardDescription: undefined,
+      workspaceId: undefined,
+      useMlsTemplate: true,
+      useDatasetTemplate: false,
+    });
+  });
+
   it('does not include boardOwnerIds in variables when not provided', async () => {
+    mocks.setResponse(successfulResponse);
+    const tool = new CreateBoardTool(mocks.mockApiClient);
+
+    await tool.execute({
+      boardName: 'Test Board',
+      boardKind: BoardKind.Public,
+    });
+
+    expect(mocks.getMockRequest()).toHaveBeenCalledWith(expect.stringContaining('mutation createBoard'), {
+      boardName: 'Test Board',
+      boardKind: BoardKind.Public,
+      boardDescription: undefined,
+      workspaceId: undefined,
+    });
+  });
+
+  it('does not include template flags in variables when not provided', async () => {
     mocks.setResponse(successfulResponse);
     const tool = new CreateBoardTool(mocks.mockApiClient);
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-board-tool.ts
@@ -1,12 +1,44 @@
 import { z } from 'zod';
 import {
   BoardKind,
-  CreateBoardMutation,
-  CreateBoardMutationVariables,
 } from '../../../monday-graphql/generated/graphql/graphql';
-import { createBoard } from '../../../monday-graphql/queries.graphql';
 import { ToolInputType, ToolOutputType, ToolType } from '../../tool';
 import { BaseMondayApiTool, createMondayApiAnnotations } from './base-monday-api-tool';
+
+const createBoardMutation = `
+  mutation createBoard(
+    $boardKind: BoardKind!
+    $boardName: String!
+    $boardDescription: String
+    $workspaceId: ID
+    $boardOwnerIds: [ID!]
+    $useMlsTemplate: Boolean
+    $useDatasetTemplate: Boolean
+  ) {
+    create_board(
+      board_kind: $boardKind
+      board_name: $boardName
+      description: $boardDescription
+      workspace_id: $workspaceId
+      board_owner_ids: $boardOwnerIds
+      use_mls_template: $useMlsTemplate
+      use_dataset_template: $useDatasetTemplate
+      empty: true
+    ) {
+      id
+      name
+      url
+    }
+  }
+`;
+
+type CreateBoardMutationResponse = {
+  create_board?: {
+    id: string;
+    name: string;
+    url: string;
+  } | null;
+};
 
 export const createBoardToolSchema = {
   boardName: z.string().describe('The name of the board to create'),
@@ -14,6 +46,8 @@ export const createBoardToolSchema = {
   boardDescription: z.string().optional().describe('The description of the board to create'),
   workspaceId: z.string().optional().describe('The ID of the workspace to create the board in'),
   boardOwnerIds: z.array(z.string()).optional().describe('Optional list of user IDs to set as board owners'),
+  useMlsTemplate: z.boolean().optional().describe('If true, creates the board from the MLS template'),
+  useDatasetTemplate: z.boolean().optional().describe('If true, creates the board from the dataset template'),
 };
 
 export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSchema, never> {
@@ -35,15 +69,17 @@ export class CreateBoardTool extends BaseMondayApiTool<typeof createBoardToolSch
   }
 
   protected async executeInternal(input: ToolInputType<typeof createBoardToolSchema>): Promise<ToolOutputType<never>> {
-    const variables: CreateBoardMutationVariables = {
+    const variables = {
       boardName: input.boardName,
       boardKind: input.boardKind,
       boardDescription: input.boardDescription,
       workspaceId: input.workspaceId,
       ...(input.boardOwnerIds !== undefined ? { boardOwnerIds: input.boardOwnerIds } : {}),
+      ...(input.useMlsTemplate !== undefined ? { useMlsTemplate: input.useMlsTemplate } : {}),
+      ...(input.useDatasetTemplate !== undefined ? { useDatasetTemplate: input.useDatasetTemplate } : {}),
     };
 
-    const res = await this.mondayApi.request<CreateBoardMutation>(createBoard, variables);
+    const res = await this.mondayApi.request<CreateBoardMutationResponse>(createBoardMutation, variables);
 
     return {
       content: { message: `Board ${res.create_board?.id} successfully created`, board_id: res.create_board?.id, board_name: res.create_board?.name, board_url: res.create_board?.url },


### PR DESCRIPTION
## Summary
- expose `useMlsTemplate` and `useDatasetTemplate` on the `create_board` MCP tool
- send the new flags through a local raw GraphQL mutation so runtime support is available before the generated schema catches up
- add focused coverage for including and omitting the new flags

## Test plan
- [x] `npx jest --config jest.config.ts --runTestsByPath src/core/tools/platform-api-tools/create-board-tool.test.ts`

## Monday item
- https://monday.monday.com/boards/205922631/pulses/12830918331

Made with [Cursor](https://cursor.com)