### PR TITLE
feat(agent-toolkit): add omitContentWhenStructured option

### DIFF
--- a/packages/agent-toolkit/src/core/monday-agent-toolkit.ts
+++ b/packages/agent-toolkit/src/core/monday-agent-toolkit.ts
@@ -39,5 +39,5 @@ export type MondayAgentToolkitConfig = {
   toolsConfiguration?: ToolsConfiguration;
   context?: MondayApiToolContext;
   fetchConfig?: FetchConfig;
-  omitContentWhenStructured?: boolean;
+  omitContentWhenStructured?: boolean | (() => boolean);
 };

--- a/packages/agent-toolkit/src/core/monday-agent-toolkit.ts
+++ b/packages/agent-toolkit/src/core/monday-agent-toolkit.ts
@@ -39,4 +39,5 @@ export type MondayAgentToolkitConfig = {
   toolsConfiguration?: ToolsConfiguration;
   context?: MondayApiToolContext;
   fetchConfig?: FetchConfig;
+  omitContentWhenStructured?: boolean;
 };

--- a/packages/agent-toolkit/src/mcp/toolkit.test.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.test.ts
@@ -1070,6 +1070,61 @@ describe('MondayAgentToolkit', () => {
       expect(toolNames).toContain('manage-tools');
     });
 
+    it('should return both structuredContent and content mirror for object results by default', async () => {
+      const objectPayload = { foo: 'bar', n: 42 };
+      const mockTool = {
+        name: 'object-result-tool',
+        type: ToolType.READ,
+        annotations: { audience: [] },
+        enabledByDefault: true,
+        getDescription: jest.fn().mockReturnValue('Object result tool'),
+        getInputSchema: jest.fn().mockReturnValue({}),
+        execute: jest.fn().mockResolvedValue({ content: objectPayload }),
+      };
+
+      mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+      const toolkit = new MondayAgentToolkit({
+        mondayApiToken: 'test-token',
+      });
+
+      const [tool] = toolkit.getToolsForMcp();
+      const result = await tool.handler({});
+
+      expect(result).toEqual({
+        structuredContent: objectPayload,
+        content: [{ type: 'text', text: JSON.stringify(objectPayload) }],
+      });
+    });
+
+    it('should omit content mirror when omitContentWhenStructured is true', async () => {
+      const objectPayload = { foo: 'bar', n: 42 };
+      const mockTool = {
+        name: 'object-result-tool-omit',
+        type: ToolType.READ,
+        annotations: { audience: [] },
+        enabledByDefault: true,
+        getDescription: jest.fn().mockReturnValue('Object result tool'),
+        getInputSchema: jest.fn().mockReturnValue({}),
+        execute: jest.fn().mockResolvedValue({ content: objectPayload }),
+      };
+
+      mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+      const toolkit = new MondayAgentToolkit({
+        mondayApiToken: 'test-token',
+        omitContentWhenStructured: true,
+      });
+
+      const [tool] = toolkit.getToolsForMcp();
+      const result = await tool.handler({});
+
+      expect(result).toEqual({
+        structuredContent: objectPayload,
+      });
+      expect(result).not.toHaveProperty('content');
+    });
+
     it('should handle tools without input schema in MCP format', async () => {
       const mockTool = {
         name: 'no-schema-mcp-tool',

--- a/packages/agent-toolkit/src/mcp/toolkit.test.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.test.ts
@@ -1125,6 +1125,71 @@ describe('MondayAgentToolkit', () => {
       expect(result).not.toHaveProperty('content');
     });
 
+    it('should omit content mirror when omitContentWhenStructured is a function returning true', async () => {
+      const objectPayload = { foo: 'bar', n: 42 };
+      const mockTool = {
+        name: 'object-result-tool-omit-fn',
+        type: ToolType.READ,
+        annotations: { audience: [] },
+        enabledByDefault: true,
+        getDescription: jest.fn().mockReturnValue('Object result tool'),
+        getInputSchema: jest.fn().mockReturnValue({}),
+        execute: jest.fn().mockResolvedValue({ content: objectPayload }),
+      };
+
+      mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+      const toolkit = new MondayAgentToolkit({
+        mondayApiToken: 'test-token',
+        omitContentWhenStructured: () => true,
+      });
+
+      const [tool] = toolkit.getToolsForMcp();
+      const result = await tool.handler({});
+
+      expect(result).toEqual({
+        structuredContent: objectPayload,
+      });
+      expect(result).not.toHaveProperty('content');
+    });
+
+    it('should re-evaluate omitContentWhenStructured function on each tool call', async () => {
+      const objectPayload = { foo: 'bar', n: 42 };
+      const mockTool = {
+        name: 'object-result-tool-reeval',
+        type: ToolType.READ,
+        annotations: { audience: [] },
+        enabledByDefault: true,
+        getDescription: jest.fn().mockReturnValue('Object result tool'),
+        getInputSchema: jest.fn().mockReturnValue({}),
+        execute: jest.fn().mockResolvedValue({ content: objectPayload }),
+      };
+
+      mockGetFilteredToolInstances.mockReturnValue([mockTool]);
+
+      let omit = false;
+      const toolkit = new MondayAgentToolkit({
+        mondayApiToken: 'test-token',
+        omitContentWhenStructured: () => omit,
+      });
+
+      const [tool] = toolkit.getToolsForMcp();
+
+      const first = await tool.handler({});
+      expect(first).toEqual({
+        structuredContent: objectPayload,
+        content: [{ type: 'text', text: JSON.stringify(objectPayload) }],
+      });
+
+      omit = true;
+
+      const second = await tool.handler({});
+      expect(second).toEqual({
+        structuredContent: objectPayload,
+      });
+      expect(second).not.toHaveProperty('content');
+    });
+
     it('should handle tools without input schema in MCP format', async () => {
       const mockTool = {
         name: 'no-schema-mcp-tool',

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -23,7 +23,7 @@ export class MondayAgentToolkit extends McpServer {
   private readonly mondayApiToken: string | (() => string);
   private readonly context?: MondayAgentToolkitConfig['context'];
   private readonly toolkitConfig: MondayAgentToolkitConfig;
-  private readonly omitContentWhenStructured: boolean;
+  private readonly omitContentWhenStructured: boolean | (() => boolean);
   private readonly dynamicToolManager: DynamicToolManager = new DynamicToolManager();
   private toolInstances: Tool<any, any>[] = [];
   private managementTool: Tool<any, any> | null = null;
@@ -355,7 +355,12 @@ export class MondayAgentToolkit extends McpServer {
       };
     }
 
-    if (this.omitContentWhenStructured) {
+    const shouldOmitContent =
+      typeof this.omitContentWhenStructured === 'function'
+        ? this.omitContentWhenStructured()
+        : this.omitContentWhenStructured === true;
+
+    if (shouldOmitContent) {
       return {
         structuredContent: content,
       } as CallToolResult;

--- a/packages/agent-toolkit/src/mcp/toolkit.ts
+++ b/packages/agent-toolkit/src/mcp/toolkit.ts
@@ -23,6 +23,7 @@ export class MondayAgentToolkit extends McpServer {
   private readonly mondayApiToken: string | (() => string);
   private readonly context?: MondayAgentToolkitConfig['context'];
   private readonly toolkitConfig: MondayAgentToolkitConfig;
+  private readonly omitContentWhenStructured: boolean;
   private readonly dynamicToolManager: DynamicToolManager = new DynamicToolManager();
   private toolInstances: Tool<any, any>[] = [];
   private managementTool: Tool<any, any> | null = null;
@@ -48,6 +49,7 @@ export class MondayAgentToolkit extends McpServer {
 
     this.mondayApiToken = config.mondayApiToken;
     this.toolkitConfig = config;
+    this.omitContentWhenStructured = config.omitContentWhenStructured ?? false;
     const resolvedToken = typeof config.mondayApiToken === 'function' ? config.mondayApiToken() : config.mondayApiToken;
     this.mondayApiClient = this.createApiClient(resolvedToken, config);
 
@@ -351,6 +353,12 @@ export class MondayAgentToolkit extends McpServer {
       return {
         content: [{ type: 'text', text: content }],
       };
+    }
+
+    if (this.omitContentWhenStructured) {
+      return {
+        structuredContent: content,
+      } as CallToolResult;
     }
 
     return {


### PR DESCRIPTION
## Summary
- Adds opt-in `omitContentWhenStructured` boolean to `MondayAgentToolkitConfig`. When `true`, `formatToolResult` skips the `content[].text` JSON mirror for object results and returns only `structuredContent`.
- Default is `false` — backwards-compatible dual-emission (per MCP spec 2025-06-18 SHOULD guidance) stays the norm; error paths and string results are untouched.
- Callers whose downstream consumers all understand `structuredContent` can flip the flag to cut per-call payload size roughly in half.