### PR TITLE
feat(agent-toolkit): short self-explaining first sentence for monday tool descriptions

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 5.65.0
+
+### Short, self-explaining first sentence for every monday tool description
+
+Deferred-tool listings show only the first sentence of a tool's description, so that sentence has to say what the tool does on its own. Audited every monday tool description (platform API + monday-dev; app tools untouched) and fixed the ones that opened with something else:
+
+- `create_item` — was `[IMPORTANT] use create_items instead…`; now leads with what the tool creates
+- `change_item_column_values` — was `[IMPORTANT] use update_items instead…`; now leads with what it changes
+- `get_asset_upload_url` — was a capability precondition; the presigned-URL summary moved to the front
+- `link_board_items_workflow` — was `When to use: …`; now leads with a one-line statement of what it returns
+- `get_sprints_metadata` — was one long sentence running into a markdown section list; now a one-line summary followed by the details
+
+No behavior changes — descriptions only; all the original guidance is kept, just reordered.
+
 ## 5.64.7
 
 ### get_board_info — nested filters to shrink large responses

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.64.7",
+  "version": "5.65.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/monday-dev-tools/get-sprints-metadata-tool/get-sprints-metadata-tool.ts
@@ -51,7 +51,9 @@ export class GetSprintsMetadataTool extends BaseMondayApiTool<typeof getSprintsM
   });
 
   getDescription(): string {
-    return `Get comprehensive sprint metadata from a monday-dev sprints board including:
+    return `List the sprints of a monday-dev sprints board with their metadata.
+
+Returns comprehensive sprint metadata including:
 
 ## Data Retrieved:
 A table of sprints with the following information:

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/change-item-column-values-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/change-item-column-values-tool.ts
@@ -44,6 +44,7 @@ export class ChangeItemColumnValuesTool extends BaseMondayApiTool<ChangeItemColu
 
   getDescription(): string {
     return (
+      'Change the column values of a single item on a monday.com board. ' +
       '[IMPORTANT] If you need to update multiple items in one call, use update_items instead of calling this tool in a loop. ' +
       'Otherwise: change the column values of a single item in a monday.com board. ' +
       "[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board's structure (column IDs, column types, status labels, etc.), first use get_board_info with filters.columns.only to get column metadata without fetching views. This is essential for constructing valid column values. " +

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-item-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/create-item-tool/create-item-tool.ts
@@ -60,6 +60,7 @@ export class CreateItemTool extends BaseMondayApiTool<CreateItemToolInput> {
 
   getDescription(): string {
     return (
+      'Create a single item or subitem on a monday.com board, or duplicate an existing item. ' +
       '[IMPORTANT] If you need to create multiple items in one call, use create_items instead of calling this tool in a loop. ' +
       'Otherwise: create a new item with provided values, create a subitem under a parent item, or duplicate an existing item and update it with new values. Use parentItemId when creating a subitem under an existing item. Use duplicateFromItemId when copying an existing item with modifications. ' +
       `[REQUIRED PRECONDITION]: Before using this tool, if new columns were added to the board or if you are not familiar with the board's structure (column IDs, column types, status labels, etc.), first use get_board_info with filters.columns.only to get column metadata without fetching views. This is essential for constructing proper column values and knowing which columns are available.`

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/get-asset-upload-url-tool/get-asset-upload-url-tool.ts
@@ -35,10 +35,10 @@ export class GetAssetUploadUrlTool extends BaseMondayApiTool<typeof getAssetUplo
 
   getDescription(): string {
     return (
+      'Get a presigned URL to upload a file to monday.com. Returns an upload_id and upload_url.\n\n' +
       'Only call this tool if you can execute a direct HTTP PUT with binary file data and read response headers ' +
       "(e.g. via shell/curl). If you can't, tell the user direct file upload isn't supported here — " +
       "don't call this tool.\n\n" +
-      'Get a presigned URL to upload a file to monday.com. Returns an upload_id and upload_url.\n\n' +
       'After calling this tool, upload the file to the returned URL using an HTTP PUT request ' +
       'and capture the ETag header from the response:\n\n' +
       'curl -i -X PUT "<upload_url>" \\\n' +

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/link-board-items-workflow-tool/link-board-items-workflow-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/link-board-items-workflow-tool/link-board-items-workflow-tool.ts
@@ -42,6 +42,7 @@ export class LinkBoardItemsWorkflowTool extends BaseMondayApiTool<typeof linkBoa
 
   getDescription(): string {
     return (
+      'Get the required playbook for linking items across boards via board-relation columns. ' +
       'When to use: any board-relation / cross-board linking task. ' +
       '**Hard gate — you MUST call this BEFORE get_board_items_page, or ' +
       'change_item_column_values in the same turn. No discovery, matching, or write happens first.** ' +


### PR DESCRIPTION
## What
Deferred-tool listings show only the **first sentence** of a tool's description, so that sentence has to explain the tool on its own.

Audited every monday tool description (platform API + monday-dev; **app tools untouched**). Most were already fine — these five opened with something other than a summary:

| Tool | Was | Now |
|---|---|---|
| `create_item` | `[IMPORTANT] use create_items instead…` | leads with what it creates |
| `change_item_column_values` | `[IMPORTANT] use update_items instead…` | leads with what it changes |
| `get_asset_upload_url` | capability precondition | presigned-URL summary moved to front |
| `link_board_items_workflow` | `When to use: …` | one-line statement of what it returns |
| `get_sprints_metadata` | long sentence running into a markdown section list | one-line summary, then details |

## Notes
- Descriptions only — no behavior changes. All original guidance is preserved, just reordered.
- Version bumped minor to `5.65.0` + CHANGELOG entry.
- `yarn test`: 71 suites / 1328 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)