### PR TITLE
fix(agent-toolkit): bump version for npm publish

### DIFF
--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.65.2",
+  "version": "5.65.3",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {


### PR DESCRIPTION
## Summary
- bump agent-toolkit to unpublished version 5.65.3
- unblock npm publishing after 5.65.2 was rejected as already published

## Test plan
- [x] Confirm 5.65.3 is unpublished on npm
- [x] Build agent-toolkit locally

## Context
- Failed commit: https://github.com/mondaycom/mcp/commit/05f861bb71488a856e9c2cb1f951de6af00db58f
- Monday task: https://monday.monday.com/boards/18426314812/pulses/12818603378

Made with [Cursor](https://cursor.com)