### PR TITLE
fix(agent-toolkit): read_docs resolves object_ids before ids

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 5.70.0
+
+### read_docs — try object_ids before ids
+
+A doc is addressable by two identifiers, `id` and `object_id`, and the number exposed in the doc URL is the `object_id` — so callers routinely pass an object_id while declaring `type: "ids"`. The lookup order now matches that reality.
+
+- For `type: "ids"`, `object_ids` is attempted first and `ids` is the fallback, so a mislabeled object_id resolves on the first request
+- `type: "object_ids"` and `type: "workspace_ids"` are unchanged and still issue a single request with no retry
+- `getDescription()` and the `type` field description now state that the number in a doc URL is the `object_id` rather than the `id`, and that results carry both so callers can pass the matching one
+- Added test coverage for the lookup order, the fallback direction, and for `type: "object_ids"` / `type: "workspace_ids"`
+
+No input schema changes, and no behaviour change for correctly labelled calls.
+
 ## 5.69.1
 
 ### Default `retrieval_only` to `true` for `get_monday_knowledge` developer docs queries

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.69.1",
+  "version": "5.70.0",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.test.ts
@@ -95,7 +95,19 @@ describe('ReadDocsTool', () => {
       expect(result.content[0].text).toContain('type and ids are required');
     });
 
-    it('should fall back to object_ids when ids returns no results', async () => {
+    it('should query object_ids first when type is "ids"', async () => {
+      mocks.mockRequest.mockResolvedValueOnce(mockDocsResponse).mockResolvedValueOnce(mockMarkdownResponse);
+
+      await callToolByNameAsync(TOOL_NAME, { type: 'ids', ids: [DOC_ID] });
+
+      expect(mocks.getMockRequest().mock.calls[0][1]).toMatchObject({
+        object_ids: [DOC_ID],
+        ids: undefined,
+      });
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(2);
+    });
+
+    it('should fall back to ids when object_ids returns no results', async () => {
       mocks.mockRequest
         .mockResolvedValueOnce(mockEmptyDocsResponse)
         .mockResolvedValueOnce(mockDocsResponse)
@@ -105,6 +117,34 @@ describe('ReadDocsTool', () => {
 
       expect(result.data).toHaveLength(1);
       expect(mocks.getMockRequest()).toHaveBeenCalledTimes(3);
+      const calls = mocks.getMockRequest().mock.calls;
+      expect(calls[0][1]).toMatchObject({ object_ids: [DOC_ID], ids: undefined });
+      expect(calls[1][1]).toMatchObject({ ids: [DOC_ID], object_ids: undefined });
+    });
+
+    it('should query object_ids without a retry when type is "object_ids"', async () => {
+      mocks.mockRequest.mockResolvedValueOnce(mockEmptyDocsResponse);
+
+      await callToolByNameRawAsync(TOOL_NAME, { type: 'object_ids', ids: ['obj_456'] });
+
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
+      expect(mocks.getMockRequest().mock.calls[0][1]).toMatchObject({
+        object_ids: ['obj_456'],
+        ids: undefined,
+      });
+    });
+
+    it('should query workspace_ids without a retry', async () => {
+      mocks.mockRequest.mockResolvedValueOnce(mockEmptyDocsResponse);
+
+      await callToolByNameRawAsync(TOOL_NAME, { type: 'workspace_ids', ids: ['ws_1'] });
+
+      expect(mocks.getMockRequest()).toHaveBeenCalledTimes(1);
+      expect(mocks.getMockRequest().mock.calls[0][1]).toMatchObject({
+        workspace_ids: ['ws_1'],
+        ids: undefined,
+        object_ids: undefined,
+      });
     });
 
     it('should return no documents message when nothing found', async () => {
@@ -636,7 +676,7 @@ describe('ReadDocsTool', () => {
       expect(result.data[0].blocks_pagination.count).toBe(7);
     });
 
-    it('should forward blocks_limit and blocks_page through the fallback object_ids retry', async () => {
+    it('should forward blocks_limit and blocks_page through the fallback ids retry', async () => {
       mocks.mockRequest
         .mockResolvedValueOnce(mockEmptyDocsResponse)
         .mockResolvedValueOnce(mockDocsWithBlocksResponse)
@@ -651,7 +691,7 @@ describe('ReadDocsTool', () => {
       });
 
       const calls = mocks.getMockRequest().mock.calls;
-      expect(calls[1][1]).toMatchObject({ blocksLimit: 10, blocksPage: 3, object_ids: [DOC_ID], ids: undefined });
+      expect(calls[1][1]).toMatchObject({ blocksLimit: 10, blocksPage: 3, ids: [DOC_ID], object_ids: undefined });
     });
 
     it('should not forward blocksLimit/blocksPage to GraphQL when include_blocks is false', async () => {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/read-docs-tool/read-docs-tool.ts
@@ -83,7 +83,7 @@ export const readDocsToolSchema = {
 
   // --- content mode fields ---
   type: QueryByIdEnum.optional().describe(
-    'Query type for content mode: "ids", "object_ids", or "workspace_ids". Required when mode is "content".',
+    'Query type for content mode: "ids" (the doc id), "object_ids" (the number visible in the doc URL), or "workspace_ids". Required when mode is "content". If the ID came from a doc URL it is an object_id — use "object_ids".',
   ),
   ids: z
     .array(z.string())
@@ -175,7 +175,9 @@ export class ReadDocsTool extends BaseMondayApiTool<typeof readDocsToolSchema> {
 MODE: "content" (default) — Fetch documents with their full markdown content.
 - Requires: type ("ids" | "object_ids" | "workspace_ids") and ids array
 - Supports pagination via page/limit. Check has_more_pages in response.
-- If type "ids" returns no results, automatically retries with object_ids.
+- A doc has two identifiers: "id" and "object_id". The number in a doc URL (https://<account>.monday.com/docs/5097882226) is the object_id, NOT the id — prefer type "object_ids" when working from a URL.
+- If type "ids" returns no results, the other identifier is tried automatically, so a mislabeled ID still resolves.
+- Results include both id and object_id — pass the matching one to other tools rather than guessing.
 - Set include_blocks: true to include block IDs, types, and positions in the response — required before calling update_doc.
 - Blocks default to 25 per page. Use blocks_limit and blocks_page to paginate through long documents.
 - Set include_comments: true to fetch all comments and replies on the document. Each comment is enriched with anchor info (block_id, selection_from, selection_length) indicating which block and text range it's attached to. Use comments_limit to control how many comments per item (default 50).
@@ -215,13 +217,16 @@ MODE: "version_history" — Fetch the edit history of a single document.
         include_blocks: input.include_blocks ?? false,
       };
 
-      let ids: string[] | undefined;
       let object_ids: string[] | undefined;
       let workspace_ids: string[] | undefined;
+      let doc_ids: string[] | undefined;
 
       switch (input.type) {
         case 'ids':
-          ids = input.ids;
+          // The number in a doc URL is the object_id, so most values passed here are object_ids.
+          // Try that first and fall back to the doc id.
+          object_ids = input.ids;
+          doc_ids = input.ids;
           break;
         case 'object_ids':
           object_ids = input.ids;
@@ -236,7 +241,7 @@ MODE: "version_history" — Fetch the edit history of a single document.
       const includeBlocks = input.include_blocks ?? false;
       const blocksPagination = includeBlocks ? { blocksLimit: input.blocks_limit, blocksPage: input.blocks_page } : {};
       const variables: ReadDocsVariables = {
-        ids,
+        ids: undefined,
         object_ids,
         limit: input.limit || 25,
         order_by: input.order_by,
@@ -248,10 +253,10 @@ MODE: "version_history" — Fetch the edit history of a single document.
 
       let res = await this.mondayApi.request<ReadDocsQuery>(readDocs, variables);
 
-      if ((!res.docs || res.docs.length === 0) && ids) {
+      if ((!res.docs || res.docs.length === 0) && doc_ids) {
         const fallbackVariables: ReadDocsVariables = {
-          ids: undefined,
-          object_ids: ids,
+          ids: doc_ids,
+          object_ids: undefined,
           limit: input.limit || 25,
           order_by: input.order_by,
           page: input.page,


### PR DESCRIPTION
## What

A doc is addressable by two identifiers, `id` and `object_id`, and the number exposed in the doc URL (`https://<account>.monday.com/docs/5097882226`) is the `object_id`. Callers therefore routinely pass an object_id while declaring `type: "ids"`.

`read_docs` previously tried `ids` first and only retried as `object_ids` after an empty result, so the common case paid for two round trips. This flips the order so the common case resolves on the first request.

## Changes

- For `type: "ids"`, `object_ids` is attempted first and `ids` is the fallback.
- The local `ids` is renamed to `doc_ids` and now feeds only the fallback request; the first request sends `ids: undefined`. The rename is not cosmetic: the retry condition tests this variable, so while it also decided what to send first, flipping the order alone would have silently disabled the fallback. Splitting the two roles keeps "what to send first" and "is a retry eligible" independent.
- `type: "object_ids"` and `type: "workspace_ids"` are unchanged — single request, no retry.
- `getDescription()` and the `type` field description now state that the number in a doc URL is the `object_id` rather than the `id`, and that results carry both so callers can pass the matching one.

## Compatibility

No input schema changes. No behaviour change for correctly labelled calls, beyond one extra lookup on the `ids` path.

## Tests

`tsc --noEmit` is clean and all 43 tests in the suite pass. Added coverage for the lookup order, the fallback direction, and for `type: "object_ids"` / `type: "workspace_ids"` — neither of the latter two was previously exercised.