### PR TITLE
fix(agent-toolkit): write a numeric assetId in finalize_asset_upload

### DIFF
--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Fix guests not being able to open files uploaded with `finalize_asset_upload`
 
-`finalize_asset_upload` wrote `assetId` into the file column as a string. monday.com compares that value against the asset's own numeric id when it decides whether a file column grants access to a file, and a string never matches, so guests on boards with permission rules saw "File not found or deleted" for every file uploaded through this tool. `assetId` is now written as a number.
+`finalize_asset_upload` wrote `assetId` into the file column as a string. monday.com compares that value against the asset's own numeric id when it decides whether a file column grants access to a file, and a string never matches, so guests on boards with permission rules saw "File not found or deleted" for every file uploaded through this tool. `complete_upload.id` is a GraphQL `ID`, which the API serializes as a string, so the tool now coerces it with `Number()` before writing `assetId`. The returned `asset_id` is coerced the same way.
 
 - `isImage` is now sent as well, so image uploads render a thumbnail in the cell.
 - `column_id` is now passed to `complete_upload`, so the asset is recorded as column bound rather than left with no columnless metadata.

--- a/packages/agent-toolkit/CHANGELOG.md
+++ b/packages/agent-toolkit/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 5.69.2
+
+### Fix guests not being able to open files uploaded with `finalize_asset_upload`
+
+`finalize_asset_upload` wrote `assetId` into the file column as a string. monday.com compares that value against the asset's own numeric id when it decides whether a file column grants access to a file, and a string never matches, so guests on boards with permission rules saw "File not found or deleted" for every file uploaded through this tool. `assetId` is now written as a number.
+
+- `isImage` is now sent as well, so image uploads render a thumbnail in the cell.
+- `column_id` is now passed to `complete_upload`, so the asset is recorded as column bound rather than left with no columnless metadata.
+
 ## 5.69.1
 
 ### Default `retrieval_only` to `true` for `get_monday_knowledge` developer docs queries

--- a/packages/agent-toolkit/package.json
+++ b/packages/agent-toolkit/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mondaydotcomorg/agent-toolkit",
-  "version": "5.69.1",
+  "version": "5.69.2",
   "description": "monday.com agent toolkit",
   "exports": {
     "./mcp": {

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.test.ts
@@ -2,7 +2,7 @@ import { createMockApiClient } from '../test-utils/mock-api-client';
 import { FinalizeAssetUploadTool } from './finalize-asset-upload-tool';
 
 const MOCK_ASSET = {
-  id: 987654,
+  id: '987654',
   filename: 'report.pdf',
   content_type: 'application/pdf',
   file_size: 1024,

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.test.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.test.ts
@@ -50,28 +50,65 @@ describe('FinalizeAssetUploadTool', () => {
           upload_id: 'uuid-upload-123',
           holder: { type: 'ITEM', id: '42' },
           board_id: '100',
+          column_id: 'file_mkvvv9cm',
           parts: [{ part_number: 1, etag: '"abc123etag"' }],
         },
       },
       expect.objectContaining({ versionOverride: 'dev' }),
     );
 
-    expect(mocks.mockRequest).toHaveBeenNthCalledWith(
-      2,
-      expect.anything(),
-      {
-        boardId: '100',
-        itemId: '42',
-        columnId: 'file_mkvvv9cm',
-        value: JSON.stringify({
-          added_file: {
-            fileType: 'ASSET',
-            name: 'report.pdf',
-            assetId: '987654',
-          },
-        }),
-      },
-    );
+    expect(mocks.mockRequest).toHaveBeenNthCalledWith(2, expect.anything(), {
+      boardId: '100',
+      itemId: '42',
+      columnId: 'file_mkvvv9cm',
+      value: JSON.stringify({
+        added_file: {
+          fileType: 'ASSET',
+          name: 'report.pdf',
+          assetId: 987654,
+          isImage: false,
+        },
+      }),
+    });
+  });
+
+  it('writes assetId as a number so monday.com column permission checks match it', async () => {
+    mocks.mockRequest.mockResolvedValueOnce({ complete_upload: MOCK_ASSET });
+    mocks.mockRequest.mockResolvedValueOnce({ change_column_value: { id: '42' } });
+
+    const tool = new FinalizeAssetUploadTool(mocks.mockApiClient);
+    await tool.execute({
+      uploadId: 'uuid-upload-123',
+      etag: '"abc123etag"',
+      boardId: '100',
+      itemId: '42',
+      columnId: 'file_mkvvv9cm',
+    });
+
+    const changeColumnValueArgs = mocks.mockRequest.mock.calls[1][1] as { value: string };
+    const addedFile = JSON.parse(changeColumnValueArgs.value).added_file;
+
+    expect(typeof addedFile.assetId).toBe('number');
+    expect(addedFile.assetId).toBe(987654);
+  });
+
+  it('marks image uploads as images', async () => {
+    mocks.mockRequest.mockResolvedValueOnce({
+      complete_upload: { ...MOCK_ASSET, filename: 'diagram.png', content_type: 'image/png' },
+    });
+    mocks.mockRequest.mockResolvedValueOnce({ change_column_value: { id: '42' } });
+
+    const tool = new FinalizeAssetUploadTool(mocks.mockApiClient);
+    await tool.execute({
+      uploadId: 'uuid-upload-123',
+      etag: '"abc123etag"',
+      boardId: '100',
+      itemId: '42',
+      columnId: 'file_mkvvv9cm',
+    });
+
+    const changeColumnValueArgs = mocks.mockRequest.mock.calls[1][1] as { value: string };
+    expect(JSON.parse(changeColumnValueArgs.value).added_file.isImage).toBe(true);
   });
 
   it('propagates complete_upload errors', async () => {
@@ -89,7 +126,13 @@ describe('FinalizeAssetUploadTool', () => {
     const tool = new FinalizeAssetUploadTool(mocks.mockApiClient);
 
     await expect(
-      tool.execute({ uploadId: 'uuid-upload-123', etag: '"abc123etag"', boardId: '100', itemId: '42', columnId: 'bad_col' }),
+      tool.execute({
+        uploadId: 'uuid-upload-123',
+        etag: '"abc123etag"',
+        boardId: '100',
+        itemId: '42',
+        columnId: 'bad_col',
+      }),
     ).rejects.toThrow('Column not found');
   });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.ts
@@ -62,6 +62,7 @@ export class FinalizeAssetUploadTool extends BaseMondayApiTool<typeof finalizeAs
           upload_id: input.uploadId,
           holder: { type: 'ITEM', id: input.itemId },
           board_id: input.boardId,
+          column_id: input.columnId,
           parts: [{ part_number: 1, etag: input.etag }],
         },
       },
@@ -71,11 +72,16 @@ export class FinalizeAssetUploadTool extends BaseMondayApiTool<typeof finalizeAs
 
     const asset = completeRes.complete_upload;
 
+    // assetId must be a number. monday.com compares it against the asset's own
+    // numeric id when deciding whether a file column grants access to a file, and
+    // a string never matches, which hides the file from guests on boards that have
+    // permission rules.
     const value = JSON.stringify({
       added_file: {
         fileType: 'ASSET',
         name: asset.filename,
-        assetId: String(asset.id),
+        assetId: asset.id,
+        isImage: asset.content_type?.startsWith('image/') ?? false,
       },
     });
 

--- a/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.ts
+++ b/packages/agent-toolkit/src/core/tools/platform-api-tools/finalize-asset-upload-tool/finalize-asset-upload-tool.ts
@@ -14,7 +14,7 @@ export const finalizeAssetUploadSchema = {
 
 interface CompleteUploadMutation {
   complete_upload: {
-    id: number;
+    id: string; // GraphQL ID scalar; serialized as a string even though the underlying id is numeric
     filename: string;
     content_type: string;
     file_size: number;
@@ -80,7 +80,7 @@ export class FinalizeAssetUploadTool extends BaseMondayApiTool<typeof finalizeAs
       added_file: {
         fileType: 'ASSET',
         name: asset.filename,
-        assetId: asset.id,
+        assetId: Number(asset.id),
         isImage: asset.content_type?.startsWith('image/') ?? false,
       },
     });
@@ -94,7 +94,7 @@ export class FinalizeAssetUploadTool extends BaseMondayApiTool<typeof finalizeAs
 
     return {
       content: {
-        asset_id: asset.id,
+        asset_id: Number(asset.id),
         filename: asset.filename,
         content_type: asset.content_type,
         file_size: asset.file_size,


### PR DESCRIPTION
## Problem

Guests on boards with column permission rules saw "File not found or deleted" for every file uploaded through `finalize_asset_upload`.

The tool wrote `assetId` into the file column value as a string. `complete_upload.id` is a GraphQL `ID` scalar, so the API serializes it as a string even though the hand written `CompleteUploadMutation` interface declared it as `number`. monday.com compares the stored `assetId` strictly against the asset's numeric id when deciding whether a file column grants access to a file, and a string never matches.

## Fix

- Coerce `complete_upload.id` with `Number()` before building the `added_file` value and in the returned `asset_id`.
- Type `complete_upload.id` as `string` to match the GraphQL schema.
- Send `isImage` so image uploads render a thumbnail in the cell.
- Pass `column_id` to `complete_upload` so the asset is recorded as column bound.
- Test mock now uses a string id, so the "assetId is a number" assertion actually exercises the coercion.

Companion monolith change: DaPulse/dapulse#114323 makes the server side comparison tolerant of ids already stored as strings.

## Tests

`yarn jest src/core/tools/platform-api-tools/finalize-asset-upload-tool` passes (6 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)